### PR TITLE
Snapping settings

### DIFF
--- a/Mergin/project_settings_widget.py
+++ b/Mergin/project_settings_widget.py
@@ -35,9 +35,17 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
         self.cmb_photo_quality.addItem("Medium (approx. 1-2 Mb)", 2)
         self.cmb_photo_quality.addItem("Low (approx. 0.5 Mb)", 3)
 
-        quality, ok = QgsProject.instance().readEntry("Mergin", "PhotoQuality")
+        quality, ok = QgsProject.instance().readNumEntry("Mergin", "PhotoQuality")
         idx = self.cmb_photo_quality.findData(quality) if ok else 0
         self.cmb_photo_quality.setCurrentIndex(idx if idx > 0 else 0)
+
+        self.cmb_snapping_mode.addItem("No snapping", 0)
+        self.cmb_snapping_mode.addItem("Basic snapping", 1)
+        self.cmb_snapping_mode.addItem("Follow QGIS snapping", 2)
+
+        mode, ok = QgsProject.instance().readNumEntry("Mergin", "Snapping")
+        idx = self.cmb_snapping_mode.findData(mode) if ok else 0
+        self.cmb_snapping_mode.setCurrentIndex(idx if idx > 0 else 0)
 
         self.local_project_dir = mergin_project_local_path()
 
@@ -84,4 +92,5 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
 
     def apply(self):
         QgsProject.instance().writeEntry("Mergin", "PhotoQuality", self.cmb_photo_quality.currentData())
+        QgsProject.instance().writeEntry("Mergin", "Snapping", self.cmb_snapping_mode.currentData())
         self.save_config_file()

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -130,7 +130,7 @@
    <item row="2" column="0" colspan="2">
     <widget class="QGroupBox" name="snapping_group_box">
      <property name="title">
-      <string>GroupBox</string>
+      <string>Snapping</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="1" column="1">

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -146,9 +146,12 @@
       <item row="0" column="0" colspan="2">
        <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By allowing snapping here, Mergin Maps Input will use snapping for this project. Learn more in the &lt;a href=&quot;https://merginmaps.com/docs/manage/snapping/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By allowing snapping here, Mergin Maps Input will use snapping for this project. Learn more in the &lt;a href=&quot;https://merginmaps.com/docs/gis/features/#project-settings&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="openExternalLinks">
          <bool>true</bool>
         </property>
        </widget>

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>495</width>
-    <height>242</height>
+    <height>367</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -65,7 +65,7 @@
       <item row="3" column="0">
        <widget class="QLabel" name="label_sync_dir">
         <property name="text">
-         <string> Only apply for folder: </string>
+         <string> Only apply for folder </string>
         </property>
        </widget>
       </item>
@@ -81,6 +81,19 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item row="1" column="0" colspan="2">
     <widget class="QGroupBox" name="photo_quality_groupbox">
@@ -115,17 +128,33 @@
     </widget>
    </item>
    <item row="2" column="0" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+    <widget class="QGroupBox" name="snapping_group_box">
+     <property name="title">
+      <string>GroupBox</string>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="1" column="1">
+       <widget class="QComboBox" name="cmb_snapping_mode"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Snapping settings</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>By allowing snapping here, Mergin Maps Input will use snapping for this project. Learn more in the documentation.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -146,7 +146,7 @@
       <item row="0" column="0" colspan="2">
        <widget class="QLabel" name="label_4">
         <property name="text">
-         <string>By allowing snapping here, Mergin Maps Input will use snapping for this project. Learn more in the documentation.</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By allowing snapping here, Mergin Maps Input will use snapping for this project. Learn more in the &lt;a href=&quot;https://merginmaps.com/docs/manage/snapping/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="wordWrap">
          <bool>true</bool>

--- a/Mergin/validation.py
+++ b/Mergin/validation.py
@@ -32,6 +32,7 @@ class Warning(Enum):
     INCORRECT_FIELD_NAME = 17
     BROKEN_VALUE_RELATION_CONFIG = 18
     ATTACHMENT_WRONG_EXPRESSION = 19
+    SNAPPING_NOT_ENABLED = 20
 
 
 class MultipleLayersWarning:
@@ -89,6 +90,7 @@ class MerginProjectValidator(object):
         self.check_project_relations()
         self.check_value_relation()
         self.check_field_names()
+        self.check_snapping()
 
         return self.issues
 
@@ -296,6 +298,13 @@ class MerginProjectValidator(object):
                     if INVALID_CHARS.search(f.name()):
                         self.issues.append(SingleLayerWarning(lid, Warning.INCORRECT_FIELD_NAME))
 
+    def check_snapping(self):
+        mode, ok = QgsProject.instance().readNumEntry("Mergin", "Snapping")
+        if ok and mode == 2:
+            enabled = QgsProject.instance().snappingConfig().enabled()
+            if not enabled:
+                self.issues.append(MultipleLayersWarning(Warning.SNAPPING_NOT_ENABLED))
+
 
 def warning_display_string(warning_id):
     """Returns a display string for a corresponing warning"""
@@ -338,3 +347,5 @@ def warning_display_string(warning_id):
         return "Incomplete value relation configuration"
     elif warning_id == Warning.ATTACHMENT_WRONG_EXPRESSION:
         return "Expression for the default path in the attachment widget configuration might be wrong. <a href='{help_mgr.howto_attachment_widget()}'>Read more.</a>"
+    elif warning_id == Warning.SNAPPING_NOT_ENABLED:
+        return "Snapping is currently disabled in this QGIS project, it will be thus disabled in Mergin Maps Input"

--- a/Mergin/validation.py
+++ b/Mergin/validation.py
@@ -311,7 +311,6 @@ class MerginProjectValidator(object):
                 self.issues.append(MultipleLayersWarning(Warning.MERGIN_SNAPPING_NOT_ENABLED))
 
 
-
 def warning_display_string(warning_id):
     """Returns a display string for a corresponing warning"""
     help_mgr = MerginHelp()

--- a/Mergin/validation.py
+++ b/Mergin/validation.py
@@ -32,7 +32,8 @@ class Warning(Enum):
     INCORRECT_FIELD_NAME = 17
     BROKEN_VALUE_RELATION_CONFIG = 18
     ATTACHMENT_WRONG_EXPRESSION = 19
-    SNAPPING_NOT_ENABLED = 20
+    QGIS_SNAPPING_NOT_ENABLED = 20
+    MERGIN_SNAPPING_NOT_ENABLED = 21
 
 
 class MultipleLayersWarning:
@@ -300,10 +301,15 @@ class MerginProjectValidator(object):
 
     def check_snapping(self):
         mode, ok = QgsProject.instance().readNumEntry("Mergin", "Snapping")
-        if ok and mode == 2:
+        if ok:
             enabled = QgsProject.instance().snappingConfig().enabled()
-            if not enabled:
-                self.issues.append(MultipleLayersWarning(Warning.SNAPPING_NOT_ENABLED))
+            if not enabled and mode == 2:
+                # snapping in Input using QGIS setting is enbaled but QGIS snapping is not activated
+                self.issues.append(MultipleLayersWarning(Warning.QGIS_SNAPPING_NOT_ENABLED))
+            if enabled and mode == 0:
+                # snapping in Input using QGIS setting is disabled but project has snapping activated
+                self.issues.append(MultipleLayersWarning(Warning.MERGIN_SNAPPING_NOT_ENABLED))
+
 
 
 def warning_display_string(warning_id):
@@ -347,5 +353,7 @@ def warning_display_string(warning_id):
         return "Incomplete value relation configuration"
     elif warning_id == Warning.ATTACHMENT_WRONG_EXPRESSION:
         return "Expression for the default path in the attachment widget configuration might be wrong. <a href='{help_mgr.howto_attachment_widget()}'>Read more.</a>"
-    elif warning_id == Warning.SNAPPING_NOT_ENABLED:
+    elif warning_id == Warning.QGIS_SNAPPING_NOT_ENABLED:
         return "Snapping is currently disabled in this QGIS project, it will be thus disabled in Mergin Maps Input"
+    elif warning_id == Warning.MERGIN_SNAPPING_NOT_ENABLED:
+        return "Snapping is currently enabled in this QGIS project, but not enabled in Mergin Maps Input"


### PR DESCRIPTION
Add Input snapping settings to the QGIS project setting
![зображення](https://user-images.githubusercontent.com/776954/174033179-0d3ad098-b89e-44c6-8289-243bc66c0a85.png)


Also add a validation for the case when "Follow QGIS snapping" mode is selected but snapping is not enabled in the project.