### PR TITLE
find project / explore public projects

### DIFF
--- a/Mergin/images/default/tabler_icons/explore.svg
+++ b/Mergin/images/default/tabler_icons/explore.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-user-search" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <circle cx="12" cy="7" r="4" />
+  <path d="M6 21v-2a4 4 0 0 1 4 -4h1" />
+  <circle cx="16.5" cy="17.5" r="2.5" />
+  <path d="M18.5 19.5l2.5 2.5" />
+</svg>

--- a/Mergin/images/default/tabler_icons/search.svg
+++ b/Mergin/images/default/tabler_icons/search.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-search" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <circle cx="10" cy="10" r="7" />
+  <line x1="21" y1="21" x2="15" y2="15" />
+</svg>

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -386,8 +386,12 @@ class MerginPlugin:
         dlg.open_project_clicked.connect(self.manager.open_project)
         dlg.download_project_clicked.connect(self.manager.download_project)
 
-        workspaces = self.mc.workspaces_list()
-        dlg.enable_workspace_switching(len(workspaces) > 1)
+        try:
+            workspaces = self.mc.workspaces_list()
+            dlg.enable_workspace_switching(len(workspaces) > 1)
+        except:
+            pass
+
         dlg.exec_()
 
     def switch_workspace(self):

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -64,13 +64,6 @@ from .processing.provider import MerginProvider
 MERGIN_CLIENT_LOG = os.path.join(QgsApplication.qgisSettingsDirPath(), "mergin-client-log.txt")
 os.environ["MERGIN_CLIENT_LOG"] = MERGIN_CLIENT_LOG
 
-try:
-    import pydevd_pycharm
-
-    pydevd_pycharm.settrace("localhost", port=6667, stdoutToServer=True, stderrToServer=True, suspend=False)
-except:
-    pass
-
 
 class MerginPlugin:
     def __init__(self, iface):

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -368,6 +368,10 @@ class MerginPlugin:
         """Synchronise current Mergin Maps project."""
         self.manager.project_status(self.mergin_proj_dir)
 
+    def find_project(self):
+        """Open new Find Mergin Maps project dialog"""
+        raise NotImplementedError
+
     def switch_workspace(self):
         """Open new Switch workspace dialog"""
         try:
@@ -386,6 +390,10 @@ class MerginPlugin:
 
         workspace = dlg.getWorkspace()
         self.set_current_workspace(workspace)
+
+    def explore_public_projects(self):
+        """Open new Explore public Mergin Maps projects dialog"""
+        raise NotImplementedError
 
     def on_qgis_project_changed(self):
         """
@@ -942,8 +950,14 @@ class MerginRootItem(QgsDataCollectionItem):
         action_create = QAction(QIcon(icon_path("square-plus.svg")), "Create new project", parent)
         action_create.triggered.connect(self.plugin.create_new_project)
 
+        action_find = QAction(QIcon(icon_path("search.svg")), "Find project", parent)
+        action_find.triggered.connect(self.plugin.find_project)
+
         action_switch = QAction(QIcon(icon_path("replace.svg")), "Switch workspace", parent)
         action_switch.triggered.connect(self.plugin.switch_workspace)
+
+        action_explore = QAction(QIcon(icon_path("explore.svg")), "Explore public projects", parent)
+        action_explore.triggered.connect(self.plugin.explore_public_projects)
 
         actions = [action_configure]
         if self.mc:
@@ -953,10 +967,14 @@ class MerginRootItem(QgsDataCollectionItem):
             elif server_type == "ee":
                 actions.append(action_refresh)
                 actions.append(action_create)
+                actions.append(action_find)
                 actions.append(action_switch)
+                actions.append(action_explore)
             elif server_type == "ce":
                 actions.append(action_refresh)
                 actions.append(action_create)
+                actions.append(action_find)
+                actions.append(action_explore)
         return actions
 
 

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -952,6 +952,7 @@ class MerginRootItem(QgsDataCollectionItem):
             server_type = self.mc.server_type()
             if server_type == "old":
                 actions.append(action_create)
+                actions.append(action_explore)
             elif server_type == "ee":
                 actions.append(action_refresh)
                 actions.append(action_create)

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -369,13 +369,16 @@ class MerginPlugin:
     def find_project(self):
         """Open new Find Mergin Maps project dialog"""
         try:
+            QgsApplication.instance().setOverrideCursor(Qt.WaitCursor)
             projects = self.mc.projects_list(
                 flag=None,
                 namespace=self.current_workspace,
                 order_params="name_asc",
             )
         except (URLError, ClientError) as e:
-            return  # Server does not support workspaces
+            return
+        finally:
+            QgsApplication.instance().restoreOverrideCursor()
 
         dlg = ProjectSelectionDialog(projects)
         dlg.new_project_clicked.connect(self.create_new_project)
@@ -385,9 +388,7 @@ class MerginPlugin:
 
         workspaces = self.mc.workspaces_list()
         dlg.enable_workspace_switching(len(workspaces) > 1)
-
-        if not dlg.exec_():
-            return
+        dlg.exec_()
 
     def switch_workspace(self):
         """Open new Switch workspace dialog"""
@@ -412,20 +413,21 @@ class MerginPlugin:
     def explore_public_projects(self):
         """Open new Explore public Mergin Maps projects dialog"""
         try:
+            QgsApplication.instance().setOverrideCursor(Qt.WaitCursor)
             projects = self.mc.projects_list(
                 flag=None,
                 order_params="namespace_asc,name_asc",
             )
+            projects = [p for p in projects if p["access"]["public"]]
         except (URLError, ClientError) as e:
             return
+        finally:
+            QgsApplication.instance().restoreOverrideCursor()
 
-        projects = [p for p in projects if p["access"]["public"]]
         dlg = PublicProjectSelectionDialog(projects)
         dlg.open_project_clicked.connect(self.manager.open_project)
         dlg.download_project_clicked.connect(self.manager.download_project)
-
-        if not dlg.exec_():
-            return
+        dlg.exec_()
 
     def on_qgis_project_changed(self):
         """

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -381,6 +381,13 @@ class MerginPlugin:
             return  # Server does not support workspaces
 
         dlg = ProjectSelectionDialog(projects)
+        dlg.new_project_clicked.connect(self.create_new_project)
+        dlg.switch_workspace_clicked.connect(self.switch_workspace)
+        dlg.open_project_clicked.connect(self.manager.open_project)
+
+        workspaces = self.mc.workspaces_list()
+        dlg.enable_workspace_switching(len(workspaces) > 1)
+
         if not dlg.exec_():
             return
 

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -64,6 +64,13 @@ from .processing.provider import MerginProvider
 MERGIN_CLIENT_LOG = os.path.join(QgsApplication.qgisSettingsDirPath(), "mergin-client-log.txt")
 os.environ["MERGIN_CLIENT_LOG"] = MERGIN_CLIENT_LOG
 
+try:
+    import pydevd_pycharm
+
+    pydevd_pycharm.settrace("localhost", port=6667, stdoutToServer=True, stderrToServer=True, suspend=False)
+except:
+    pass
+
 
 class MerginPlugin:
     def __init__(self, iface):
@@ -378,19 +385,7 @@ class MerginPlugin:
 
     def find_project(self):
         """Open new Find Mergin Maps project dialog"""
-        try:
-            QgsApplication.instance().setOverrideCursor(Qt.WaitCursor)
-            projects = self.mc.projects_list(
-                flag=None,
-                namespace=self.current_workspace,
-                order_params="name_asc",
-            )
-        except (URLError, ClientError) as e:
-            return
-        finally:
-            QgsApplication.instance().restoreOverrideCursor()
-
-        dlg = ProjectSelectionDialog(projects)
+        dlg = ProjectSelectionDialog(self.mc, self.current_workspace_name)
         dlg.new_project_clicked.connect(self.create_new_project)
         dlg.switch_workspace_clicked.connect(self.switch_workspace)
         dlg.open_project_clicked.connect(self.manager.open_project)
@@ -426,19 +421,7 @@ class MerginPlugin:
 
     def explore_public_projects(self):
         """Open new Explore public Mergin Maps projects dialog"""
-        try:
-            QgsApplication.instance().setOverrideCursor(Qt.WaitCursor)
-            projects = self.mc.projects_list(
-                flag=None,
-                order_params="namespace_asc,name_asc",
-            )
-            projects = [p for p in projects if p["access"]["public"]]
-        except (URLError, ClientError) as e:
-            return
-        finally:
-            QgsApplication.instance().restoreOverrideCursor()
-
-        dlg = PublicProjectSelectionDialog(projects)
+        dlg = PublicProjectSelectionDialog(self.mc)
         dlg.open_project_clicked.connect(self.manager.open_project)
         dlg.download_project_clicked.connect(self.manager.download_project)
         dlg.exec_()

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -31,6 +31,7 @@ from urllib.error import URLError
 
 from .configuration_dialog import ConfigurationDialog
 from .workspace_selection_dialog import WorkspaceSelectionDialog
+from .project_selection_dialog import ProjectSelectionDialog
 from .create_project_wizard import NewMerginProjectWizard
 from .clone_project_dialog import CloneProjectDialog
 from .diff_dialog import DiffViewerDialog
@@ -370,7 +371,18 @@ class MerginPlugin:
 
     def find_project(self):
         """Open new Find Mergin Maps project dialog"""
-        raise NotImplementedError
+        try:
+            projects = self.mc.projects_list(
+                flag=None,
+                namespace=self.current_workspace,
+                order_params="name_asc",
+            )
+        except (URLError, ClientError) as e:
+            return  # Server does not support workspaces
+
+        dlg = ProjectSelectionDialog(projects)
+        if not dlg.exec_():
+            return
 
     def switch_workspace(self):
         """Open new Switch workspace dialog"""

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -31,7 +31,7 @@ from urllib.error import URLError
 
 from .configuration_dialog import ConfigurationDialog
 from .workspace_selection_dialog import WorkspaceSelectionDialog
-from .project_selection_dialog import ProjectSelectionDialog
+from .project_selection_dialog import ProjectSelectionDialog, PublicProjectSelectionDialog
 from .create_project_wizard import NewMerginProjectWizard
 from .clone_project_dialog import CloneProjectDialog
 from .diff_dialog import DiffViewerDialog
@@ -413,7 +413,21 @@ class MerginPlugin:
 
     def explore_public_projects(self):
         """Open new Explore public Mergin Maps projects dialog"""
-        raise NotImplementedError
+        try:
+            projects = self.mc.projects_list(
+                flag=None,
+                order_params="namespace_asc,name_asc",
+            )
+        except (URLError, ClientError) as e:
+            return
+
+        projects = [p for p in projects if p["access"]["public"]]
+        dlg = PublicProjectSelectionDialog(projects)
+        dlg.open_project_clicked.connect(self.manager.open_project)
+        dlg.download_project_clicked.connect(self.manager.download_project)
+
+        if not dlg.exec_():
+            return
 
     def on_qgis_project_changed(self):
         """

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -873,10 +873,11 @@ class MerginRootItem(QgsDataCollectionItem):
         try:
             resp = self.project_manager.mc.paginated_projects_list(
                 flag=self.filter,
-                namespace=self.workspace,
+                only_namespace=self.workspace,
                 page=page,
                 per_page=per_page,
-                order_params="namespace_asc,name_asc",
+                # todo: switch back to "namespace_asc,name_asc" as it currently crashes ee.dev and ce.dev
+                order_params="name_asc",
             )
             self.projects += resp["projects"]
             self.total_projects_count = int(resp["count"]) if is_number(resp["count"]) else 0

--- a/Mergin/project_selection_dialog.py
+++ b/Mergin/project_selection_dialog.py
@@ -95,7 +95,7 @@ class ProjectsModel(QAbstractListModel):
             elif status in (SyncStatus.LOCAL_CHANGES, SyncStatus.REMOTE_CHANGES):
                 icon = "refresh.svg"
             return icon
-        return project["name"]
+        return "{} / {}".format(project["namespace"], project["name"])
 
     def localProjectPath(self, project):
         project_name = posixpath.join(project["namespace"], project["name"])  # posix path for server API calls
@@ -157,7 +157,7 @@ class ProjectItemDelegate(QAbstractItemDelegate):
         painter.drawRect(borderRect)
         painter.setFont(nameFont)
         if self.show_namespace:
-            text = "{} / {}".format(index.data(ProjectsModel.NAMESPACE), index.data(ProjectsModel.NAME))
+            text = index.data(Qt.DisplayRole)
         else:
             text = index.data(ProjectsModel.NAME)
         painter.drawText(nameRect, Qt.AlignLeading, text)

--- a/Mergin/project_selection_dialog.py
+++ b/Mergin/project_selection_dialog.py
@@ -121,11 +121,11 @@ class ProjectItemDelegate(QAbstractItemDelegate):
         super(ProjectItemDelegate, self).__init__()
         self.show_namespace = show_namespace
 
-    def sizeHint(self, option: "QStyleOptionViewItem", index: QModelIndex) -> QSize:
+    def sizeHint(self, option, index):
         fm = QFontMetrics(option.font)
         return QSize(150, fm.height() * 3 + fm.leading())
 
-    def paint(self, painter: QPainter, option: "QStyleOptionViewItem", index: QModelIndex) -> None:
+    def paint(self, painter, option, index):
         nameFont = QFont(option.font)
         fm = QFontMetrics(nameFont)
         padding = fm.lineSpacing() // 2

--- a/Mergin/project_selection_dialog.py
+++ b/Mergin/project_selection_dialog.py
@@ -119,24 +119,19 @@ class ProjectItemDelegate(QAbstractItemDelegate):
 
     def paint(self, painter, option, index):
         nameFont = QFont(option.font)
+        nameFont.setWeight(QFont.Weight.Bold)
         fm = QFontMetrics(nameFont)
         padding = fm.lineSpacing() // 2
-        nameFont.setWeight(QFont.Weight.Bold)
 
         nameRect = QRect(option.rect)
         nameRect.setLeft(nameRect.left() + padding)
         nameRect.setTop(nameRect.top() + padding)
         nameRect.setRight(nameRect.right() - 50)
         nameRect.setHeight(fm.lineSpacing())
-        infoRect = fm.boundingRect(
-            nameRect.left(),
-            nameRect.bottom() + fm.leading(),
-            nameRect.width(),
-            0,
-            Qt.AlignLeading,
-            index.data(ProjectsModel.STATUS),
-        )
-        infoRect.setTop(infoRect.bottom() - fm.lineSpacing())
+        infoRect = QRect(option.rect)
+        infoRect.setLeft(infoRect.left() + padding)
+        infoRect.setTop(infoRect.bottom() - padding - fm.lineSpacing())
+        infoRect.setRight(infoRect.right() - 50)
         infoRect.setHeight(fm.lineSpacing())
         borderRect = QRect(option.rect.marginsRemoved(QMargins(4, 4, 4, 4)))
         iconRect = QRect(borderRect)
@@ -152,9 +147,12 @@ class ProjectItemDelegate(QAbstractItemDelegate):
             text = index.data(Qt.DisplayRole)
         else:
             text = index.data(ProjectsModel.NAME)
-        painter.drawText(nameRect, Qt.AlignLeading, text)
+        elided_text = fm.elidedText(text, Qt.ElideRight, nameRect.width())
+        painter.drawText(nameRect, Qt.AlignLeading, elided_text)
         painter.setFont(option.font)
-        painter.drawText(infoRect, Qt.AlignLeading, index.data(ProjectsModel.STATUS))
+        fm = QFontMetrics(QFont(option.font))
+        elided_status = fm.elidedText(index.data(ProjectsModel.STATUS), Qt.ElideRight, infoRect.width())
+        painter.drawText(infoRect, Qt.AlignLeading, elided_status)
         icon = index.data(ProjectsModel.ICON)
         if icon:
             icon = QIcon(icon_path(icon))

--- a/Mergin/project_selection_dialog.py
+++ b/Mergin/project_selection_dialog.py
@@ -204,6 +204,7 @@ class ProjectSelectionDialog(QDialog):
         self.ui.line_edit.textChanged.connect(self.on_text_changed)
         self.ui.line_edit.setFocus()
 
+        self.ui.open_project_btn.setEnabled(False)
         self.ui.open_project_btn.clicked.connect(self.on_open_project_clicked)
 
         self.ui.new_project_btn.clicked.connect(self.on_new_project_clicked)
@@ -239,8 +240,9 @@ class ProjectSelectionDialog(QDialog):
             )
             self.proxy.setFilterFixedString("")
             if self.request_page == 1:
-                self.model.clear()
+                self.ui.project_list.clearSelection()
                 self.ui.project_list.scrollToTop()
+                self.model.clear()
                 self.fetched_projects_number = 0
             self.model.appendProjects(projects["projects"])
 

--- a/Mergin/project_selection_dialog.py
+++ b/Mergin/project_selection_dialog.py
@@ -100,7 +100,7 @@ class ProjectsModel(QStandardItemModel):
 
         mp = MerginProject(local_proj_path)
         local_changes = mp.get_push_changes()
-        if local_changes["added"] or local_changes["updated"]:
+        if local_changes["added"] or local_changes["removed"] or local_changes["updated"]:
             return SyncStatus.LOCAL_CHANGES
         elif compare_versions(project["version"], mp.metadata["version"]) > 0:
             return SyncStatus.REMOTE_CHANGES

--- a/Mergin/project_selection_dialog.py
+++ b/Mergin/project_selection_dialog.py
@@ -1,0 +1,88 @@
+import os
+import posixpath
+from qgis.PyQt.QtWidgets import QDialog, QListWidget, QListWidgetItem, QListView, QAbstractItemDelegate, QStyle
+from qgis.PyQt.QtCore import QSize, QSortFilterProxyModel, QStringListModel, Qt, QModelIndex, QRect, QMargins
+from qgis.PyQt import uic
+from qgis.PyQt.QtGui import QPixmap, QPainter, QStandardItemModel, QStandardItem, QFont, QFontMetrics
+
+from .utils import (
+    icon_path,
+    mergin_project_local_path,
+)
+
+ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "ui_select_project_dialog.ui")
+
+
+class ProjectItemDelegate(QAbstractItemDelegate):
+    def __init__(self):
+        super(ProjectItemDelegate, self).__init__()
+
+    def sizeHint(self, option: 'QStyleOptionViewItem', index: QModelIndex) -> QSize:
+        fm = QFontMetrics(option.font)
+        return QSize(150, fm.height() * 3 + fm.leading())
+
+    def paint(self, painter: QPainter, option: 'QStyleOptionViewItem', index: QModelIndex) -> None:
+        painter.save()
+        if option.state & QStyle.State_Selected:
+            painter.fillRect(option.rect.marginsRemoved(QMargins(4, 4, 4, 4)), option.palette.highlight());
+
+        nameFont = QFont(option.font)
+        infoFont = QFont(option.font)
+        nameFont.setWeight(QFont.Weight.Bold)
+        fm = QFontMetrics(nameFont)
+        nameRect = QRect(option.rect)
+        nameRect.setLeft(nameRect.left() + fm.lineSpacing() // 2)
+        nameRect.setTop(nameRect.top() + fm.lineSpacing() // 2)
+        nameRect.setHeight(fm.lineSpacing())
+        infoRect = fm.boundingRect(nameRect.left(), nameRect.bottom() + fm.leading(), nameRect.width(), 0, Qt.AlignLeading, index.data(Qt.UserRole + 1))
+        infoRect.setTop(infoRect.bottom() - fm.lineSpacing())
+        infoRect.setHeight(fm.lineSpacing())
+
+        painter.drawRect(option.rect.marginsRemoved(QMargins(4, 4, 4, 4)))
+        painter.setFont(nameFont)
+        painter.drawText(nameRect, Qt.AlignLeading, index.data(Qt.DisplayRole))
+        painter.setFont(infoFont)
+        painter.drawText(infoRect, Qt.AlignLeading, index.data(Qt.UserRole + 1))
+        painter.restore()
+
+
+class ProjectSelectionDialog(QDialog):
+    def __init__(self, projects):
+        QDialog.__init__(self)
+        self.ui = uic.loadUi(ui_file, self)
+
+        self.ui.label_logo.setPixmap(QPixmap(icon_path("mm_icon_positive_no_padding.svg", True)))
+
+        project_names = [w["name"] for w in projects]
+        self.model = QStandardItemModel()
+        for project in projects:
+            item = QStandardItem(project["name"])
+
+            project_name = posixpath.join(project["namespace"], project["name"])  # posix path for server API calls
+            local_proj_path = mergin_project_local_path(project_name)
+            if local_proj_path is None or not os.path.exists(local_proj_path):
+                item.setData("Remote", Qt.UserRole + 1)
+            else:
+                item.setData("Local", Qt.UserRole + 1)
+
+            self.model.appendRow(item)
+
+        self.proxy = QSortFilterProxyModel()
+        self.proxy.setSourceModel(self.model)
+        self.proxy.setFilterCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+
+        self.ui.project_list.setModel(self.proxy)
+        delegate = ProjectItemDelegate()
+        self.ui.project_list.setItemDelegate(delegate)
+        self.ui.project_list.doubleClicked.connect(self.on_double_click)
+
+        self.ui.line_edit.setShowSearchIcon(True)
+        self.ui.line_edit.setVisible(len(projects) >= 5)
+        self.ui.line_edit.textChanged.connect(self.proxy.setFilterFixedString)
+
+    def on_double_click(self, index):
+        self.workspace = self.proxy.data(index, Qt.EditRole)
+        self.accept()
+
+    def getWorkspace(self):
+        return self.workspace

--- a/Mergin/project_selection_dialog.py
+++ b/Mergin/project_selection_dialog.py
@@ -1,9 +1,9 @@
 import os
 import posixpath
 from qgis.PyQt.QtWidgets import QDialog, QListView, QAbstractItemDelegate, QStyle
-from qgis.PyQt.QtCore import QSize, QSortFilterProxyModel, QAbstractListModel, Qt, QModelIndex, QRect, QMargins, pyqtSignal
+from qgis.PyQt.QtCore import QSize, QSortFilterProxyModel, QAbstractListModel, Qt, QModelIndex, QRect, QMargins, pyqtSignal, QEvent
 from qgis.PyQt import uic
-from qgis.PyQt.QtGui import QPixmap, QPainter, QStandardItemModel, QStandardItem, QFont, QFontMetrics
+from qgis.PyQt.QtGui import QPixmap, QPainter, QStandardItemModel, QStandardItem, QFont, QFontMetrics, QIcon, QKeyEvent
 
 from .mergin.merginproject import MerginProject
 from .utils import (
@@ -138,10 +138,10 @@ class ProjectItemDelegate(QAbstractItemDelegate):
         painter.drawText(nameRect, Qt.AlignLeading, index.data(Qt.DisplayRole))
         painter.setFont(option.font)
         painter.drawText(infoRect, Qt.AlignLeading, index.data(ProjectsModel.STATUS))
-        painter.drawRect(iconRect)
         icon = index.data(ProjectsModel.ICON)
         if icon:
-            painter.drawPixmap(iconRect, QPixmap(icon_path(icon)))
+            icon = QIcon(icon_path(icon))
+            icon.paint(painter, iconRect)
         painter.restore()
 
 
@@ -208,4 +208,3 @@ class ProjectSelectionDialog(QDialog):
 
     def enable_workspace_switching(self, enable):
         self.ui.switch_workspace_label.setVisible(enable)
-

--- a/Mergin/project_selection_dialog.py
+++ b/Mergin/project_selection_dialog.py
@@ -157,7 +157,7 @@ class ProjectItemDelegate(QAbstractItemDelegate):
         painter.drawRect(borderRect)
         painter.setFont(nameFont)
         if self.show_namespace:
-            text = '{} / {}'.format(index.data(ProjectsModel.NAMESPACE), index.data(ProjectsModel.NAME))
+            text = "{} / {}".format(index.data(ProjectsModel.NAMESPACE), index.data(ProjectsModel.NAME))
         else:
             text = index.data(ProjectsModel.NAME)
         painter.drawText(nameRect, Qt.AlignLeading, text)

--- a/Mergin/project_selection_dialog.py
+++ b/Mergin/project_selection_dialog.py
@@ -52,9 +52,6 @@ class ProjectsModel(QAbstractListModel):
     def rowCount(self, parent=None, *args, **kwargs):
         return len(self.projects)
 
-    # def index(self, row, column):
-    #     return self.createIndex(row, 0)
-
     def data(self, index, role):
         project = self.projects[index.row()]
         if role == ProjectsModel.NAME:
@@ -87,8 +84,7 @@ class ProjectsModel(QAbstractListModel):
         return mergin_project_local_path(project_name)
 
     def status(self, project):
-        project_name = posixpath.join(project["namespace"], project["name"])  # posix path for server API calls
-        local_proj_path = mergin_project_local_path(project_name)
+        local_proj_path = self.localProjectPath(project)
         if local_proj_path is None or not os.path.exists(local_proj_path):
             return "Not downloaded"
 

--- a/Mergin/project_selection_dialog.py
+++ b/Mergin/project_selection_dialog.py
@@ -181,7 +181,7 @@ class ProjectSelectionDialog(QDialog):
         QDialog.__init__(self)
         self.ui = uic.loadUi(ui_file, self, "Mergin")
 
-        self.ui.label_logo.setPixmap(QPixmap(icon_path("mm_icon_positive_no_padding.svg", True)))
+        self.ui.label_logo.setPixmap(QPixmap(icon_path("mm_logo.svg", False)))
 
         self.model = ProjectsModel(projects)
 

--- a/Mergin/project_selection_dialog.py
+++ b/Mergin/project_selection_dialog.py
@@ -1,7 +1,7 @@
 import os
 import posixpath
-from qgis.PyQt.QtWidgets import QDialog, QListWidget, QListWidgetItem, QListView, QAbstractItemDelegate, QStyle
-from qgis.PyQt.QtCore import QSize, QSortFilterProxyModel, QStringListModel, Qt, QModelIndex, QRect, QMargins
+from qgis.PyQt.QtWidgets import QDialog, QListView, QAbstractItemDelegate, QStyle
+from qgis.PyQt.QtCore import QSize, QSortFilterProxyModel, QAbstractListModel, Qt, QModelIndex, QRect, QMargins, pyqtSignal
 from qgis.PyQt import uic
 from qgis.PyQt.QtGui import QPixmap, QPainter, QStandardItemModel, QStandardItem, QFont, QFontMetrics
 
@@ -9,9 +9,97 @@ from .mergin.merginproject import MerginProject
 from .utils import (
     icon_path,
     mergin_project_local_path,
+    compare_versions,
 )
 
 ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "ui_select_project_dialog.ui")
+
+
+class ProjectListView(QListView):
+
+    currentIndexChanged = pyqtSignal(QModelIndex)
+
+    def __init__(self, parent):
+        super(ProjectListView, self).__init__(parent)
+
+    def currentChanged(self, current, previous):
+        super(ProjectListView, self).currentChanged(current, previous)
+        self.currentIndexChanged.emit(current)
+
+    def selectedIndex(self):
+        try:
+            return self.selectedIndexes()[0]
+        except IndexError:
+            return QModelIndex()
+
+
+class ProjectsModel(QAbstractListModel):
+
+    NAME = Qt.UserRole + 1
+    NAMESPACE = Qt.UserRole + 2
+    FULLNAME = Qt.UserRole + 3
+    ISLOCAL = Qt.UserRole + 4
+    FILEPATH = Qt.UserRole + 5
+    VERSION = Qt.UserRole + 6
+    STATUS = Qt.UserRole + 7
+    DIRECTORY = Qt.UserRole + 8
+    ICON = Qt.UserRole + 9
+
+    def __init__(self, projects):
+        super(ProjectsModel, self).__init__()
+        self.projects = projects
+
+    def rowCount(self, parent=None, *args, **kwargs):
+        return len(self.projects)
+
+    # def index(self, row, column):
+    #     return self.createIndex(row, 0)
+
+    def data(self, index, role):
+        project = self.projects[index.row()]
+        if role == ProjectsModel.NAME:
+            return project["name"]
+        if role == ProjectsModel.NAMESPACE:
+            return project["namespace"]
+        if role == ProjectsModel.VERSION:
+            return project["version"]
+        if role == ProjectsModel.ISLOCAL:
+            local_proj_path = self.locaProjectPath()
+            return local_proj_path and os.path.exists(local_proj_path)
+        if role == ProjectsModel.STATUS:
+            return self.status(project)
+        if role == ProjectsModel.DIRECTORY:
+            return self.localProjectPath(project)
+        if role == ProjectsModel.ICON:
+            status = self.status(project)
+            icon = ""
+            if status == "Not downloaded":
+                icon = "cloud-download.svg"
+            elif status == "Local changes waiting to be pushed":
+                icon = "refresh.svg"
+            elif status == "Update available":
+                icon = "refresh"
+            return icon
+        return project["name"]
+
+    def localProjectPath(self, project):
+        project_name = posixpath.join(project["namespace"], project["name"])  # posix path for server API calls
+        return mergin_project_local_path(project_name)
+
+    def status(self, project):
+        project_name = posixpath.join(project["namespace"], project["name"])  # posix path for server API calls
+        local_proj_path = mergin_project_local_path(project_name)
+        if local_proj_path is None or not os.path.exists(local_proj_path):
+            return "Not downloaded"
+
+        mp = MerginProject(local_proj_path)
+        local_changes = mp.get_push_changes()
+        if local_changes["added"] or local_changes["updated"]:
+            return "Local changes waiting to be pushed"
+        elif compare_versions(project["version"], mp.metadata["version"]) > 0:
+            return "Update available"
+        else:
+            return "Up to date"
 
 
 class ProjectItemDelegate(QAbstractItemDelegate):
@@ -23,58 +111,53 @@ class ProjectItemDelegate(QAbstractItemDelegate):
         return QSize(150, fm.height() * 3 + fm.leading())
 
     def paint(self, painter: QPainter, option: 'QStyleOptionViewItem', index: QModelIndex) -> None:
-        painter.save()
-        if option.state & QStyle.State_Selected:
-            painter.fillRect(option.rect.marginsRemoved(QMargins(4, 4, 4, 4)), option.palette.highlight());
-
         nameFont = QFont(option.font)
-        infoFont = QFont(option.font)
-        nameFont.setWeight(QFont.Weight.Bold)
         fm = QFontMetrics(nameFont)
+        padding = fm.lineSpacing() // 2
+        nameFont.setWeight(QFont.Weight.Bold)
+
+
         nameRect = QRect(option.rect)
-        nameRect.setLeft(nameRect.left() + fm.lineSpacing() // 2)
-        nameRect.setTop(nameRect.top() + fm.lineSpacing() // 2)
+        nameRect.setLeft(nameRect.left() + padding)
+        nameRect.setTop(nameRect.top() + padding)
+        nameRect.setRight(nameRect.right() - 50 )
         nameRect.setHeight(fm.lineSpacing())
-        infoRect = fm.boundingRect(nameRect.left(), nameRect.bottom() + fm.leading(), nameRect.width(), 0, Qt.AlignLeading, index.data(Qt.UserRole + 1))
+        infoRect = fm.boundingRect(nameRect.left(), nameRect.bottom() + fm.leading(), nameRect.width(), 0, Qt.AlignLeading, index.data(ProjectsModel.STATUS))
         infoRect.setTop(infoRect.bottom() - fm.lineSpacing())
         infoRect.setHeight(fm.lineSpacing())
+        borderRect = QRect(option.rect.marginsRemoved(QMargins(4, 4, 4, 4)))
+        iconRect = QRect(borderRect)
+        iconRect.setLeft(nameRect.right())
+        iconRect = iconRect.marginsRemoved(QMargins(10, 10, 10, 10))
 
-        painter.drawRect(option.rect.marginsRemoved(QMargins(4, 4, 4, 4)))
+        painter.save()
+        if option.state & QStyle.State_Selected:
+            painter.fillRect(borderRect, option.palette.highlight());
+        painter.drawRect(borderRect)
         painter.setFont(nameFont)
         painter.drawText(nameRect, Qt.AlignLeading, index.data(Qt.DisplayRole))
-        painter.setFont(infoFont)
-        painter.drawText(infoRect, Qt.AlignLeading, index.data(Qt.UserRole + 1))
+        painter.setFont(option.font)
+        painter.drawText(infoRect, Qt.AlignLeading, index.data(ProjectsModel.STATUS))
+        painter.drawRect(iconRect)
+        icon = index.data(ProjectsModel.ICON)
+        if icon:
+            painter.drawPixmap(iconRect, QPixmap(icon_path(icon)))
         painter.restore()
 
 
 class ProjectSelectionDialog(QDialog):
+
+    new_project_clicked = pyqtSignal()
+    switch_workspace_clicked = pyqtSignal()
+    open_project_clicked = pyqtSignal(str)
+
     def __init__(self, projects):
         QDialog.__init__(self)
-        self.ui = uic.loadUi(ui_file, self)
+        self.ui = uic.loadUi(ui_file, self, "Mergin")
 
         self.ui.label_logo.setPixmap(QPixmap(icon_path("mm_icon_positive_no_padding.svg", True)))
 
-        project_names = [w["name"] for w in projects]
-        self.model = QStandardItemModel()
-        for project in projects:
-            item = QStandardItem(project["name"])
-
-            project_name = posixpath.join(project["namespace"], project["name"])  # posix path for server API calls
-            local_proj_path = mergin_project_local_path(project_name)
-            if local_proj_path is None or not os.path.exists(local_proj_path):
-                item.setData("Not downloaded", Qt.UserRole + 1)
-            else:
-                mp = MerginProject(local_proj_path)
-                local_changes = mp.get_push_changes()
-                if local_changes["added"] or local_changes["updated"]:
-                    item.setData("Local changes waiting to be pushed", Qt.UserRole + 1)
-                elif mp.metadata["version"] < project["version"]:  # todo: proper compare
-                    item.setData("Update available", Qt.UserRole + 1)
-                else:
-                    item.setData("Up to date", Qt.UserRole + 1)
-
-
-            self.model.appendRow(item)
+        self.model = ProjectsModel(projects)
 
         self.proxy = QSortFilterProxyModel()
         self.proxy.setSourceModel(self.model)
@@ -84,14 +167,45 @@ class ProjectSelectionDialog(QDialog):
         delegate = ProjectItemDelegate()
         self.ui.project_list.setItemDelegate(delegate)
         self.ui.project_list.doubleClicked.connect(self.on_double_click)
+        self.ui.project_list.currentIndexChanged.connect(self.on_current_changed)
 
         self.ui.line_edit.setShowSearchIcon(True)
         self.ui.line_edit.setVisible(len(projects) >= 5)
         self.ui.line_edit.textChanged.connect(self.proxy.setFilterFixedString)
+        self.ui.line_edit.setFocus()
+
+        self.ui.open_project_btn.setEnabled(False)
+        self.ui.open_project_btn.clicked.connect(self.on_open_project_clicked)
+        self.ui.new_project_btn.clicked.connect(self.on_new_project_clicked)
+        self.ui.switch_workspace_label.linkActivated.connect(self.on_switch_workspace_clicked)
+
+    def on_current_changed(self, index):
+        project_path = self.proxy.data(index, ProjectsModel.DIRECTORY)
+        self.ui.open_project_btn.setEnabled(bool(project_path))
+
+    def on_open_project_clicked(self):
+        index = self.ui.project_list.selectedIndex()
+        if not index.isValid():
+            return
+
+        project_path = self.proxy.data(index, ProjectsModel.DIRECTORY)
+        if not project_path:
+            return
+
+        self.close()
+        self.open_project_clicked.emit(project_path)
+
+    def on_new_project_clicked(self):
+        self.close()
+        self.new_project_clicked.emit()
+
+    def on_switch_workspace_clicked(self):
+        self.close()
+        self.switch_workspace_clicked.emit()
 
     def on_double_click(self, index):
-        self.workspace = self.proxy.data(index, Qt.EditRole)
-        self.accept()
+        self.on_open_project_clicked()
 
-    def getWorkspace(self):
-        return self.workspace
+    def enable_workspace_switching(self, enable):
+        self.ui.switch_workspace_label.setVisible(enable)
+

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -1,9 +1,11 @@
 import os
 from urllib.parse import urlparse
+from pathlib import Path
+import posixpath
 
-from qgis.core import QgsProject, Qgis
+from qgis.core import QgsProject, Qgis, QgsApplication
 from qgis.utils import iface
-from qgis.PyQt.QtWidgets import QMessageBox, QApplication, QPushButton
+from qgis.PyQt.QtWidgets import QMessageBox, QApplication, QPushButton, QFileDialog
 from qgis.PyQt.QtCore import QSettings, Qt, QTimer
 from urllib.error import URLError
 
@@ -432,3 +434,62 @@ class MerginProjectsManager(object):
         # we have to wait a bit to let the OS (Windows) release lock on the GPKG files
         # otherwise attempt to resolve unfinished pull will fail
         QTimer.singleShot(delay, lambda: self.resolve_unfinished_pull(project_dir, True))
+
+    def download_project(self, project):
+        project_name = posixpath.join(project["namespace"], project["name"])  # we need posix path for server API calls
+        settings = QSettings()
+        last_parent_dir = settings.value("Mergin/lastUsedDownloadDir", str(Path.home()))
+        parent_dir = QFileDialog.getExistingDirectory(None, "Open Directory", last_parent_dir, QFileDialog.ShowDirsOnly)
+        if not parent_dir:
+            return
+        settings.setValue("Mergin/lastUsedDownloadDir", parent_dir)
+        target_dir = os.path.abspath(os.path.join(parent_dir, project["name"]))
+        if os.path.exists(target_dir):
+            QMessageBox.warning(
+                None,
+                "Download Project",
+                "The target directory already exists:\n" + target_dir + "\n\nPlease select a different directory.",
+            )
+            return
+
+        dlg = SyncDialog()
+        dlg.download_start(self.mc, target_dir, project_name)
+        dlg.exec_()  # blocks until completion / failure / cancellation
+        if dlg.exception:
+            if isinstance(dlg.exception, (URLError, ValueError)):
+                QgsApplication.messageLog().logMessage("Mergin Maps plugin: " + str(dlg.exception))
+                msg = (
+                    "Failed to download your project {}.\n"
+                    "Please make sure your Mergin Maps settings are correct".format(project_name)
+                )
+                QMessageBox.critical(None, "Project download", msg, QMessageBox.Close)
+            elif isinstance(dlg.exception, LoginError):
+                login_error_message(dlg.exception)
+            else:
+                unhandled_exception_message(
+                    dlg.exception_details(),
+                    "Project download",
+                    f"Failed to download project {project_name} due to an unhandled exception.",
+                )
+            return
+        if not dlg.is_complete:
+            return  # either it has been cancelled or an error has been thrown
+
+        settings.setValue("Mergin/localProjects/{}/path".format(project_name), target_dir)
+        msg = "Your project {} has been successfully downloaded. Do you want to open project file?".format(project_name)
+        btn_reply = QMessageBox.question(
+            None, "Project download", msg, QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes
+        )
+        if btn_reply == QMessageBox.Yes:
+            self.open_project(target_dir)
+
+        # reload the two browser groups (in case server is old)
+        groups = self.get_mergin_browser_groups()
+        for group in groups:
+            groups[group].reload()
+
+        # reload the Mergin Maps browser entry (in case server is ee/ce)
+        browser_model = self.iface.browserModel()
+        root_idx = browser_model.findPath("Mergin Maps")
+        item = browser_model.dataItem(root_idx)
+        item.reload()

--- a/Mergin/ui/ui_select_project_dialog.ui
+++ b/Mergin/ui/ui_select_project_dialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Find project</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="4" column="0">

--- a/Mergin/ui/ui_select_project_dialog.ui
+++ b/Mergin/ui/ui_select_project_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>393</width>
-    <height>432</height>
+    <width>502</width>
+    <height>586</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -40,6 +40,9 @@
      </property>
      <property name="text">
       <string>Open project</string>
+     </property>
+     <property name="autoDefault">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -83,6 +86,9 @@
      <property name="text">
       <string>Create new project</string>
      </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
     </widget>
    </item>
   </layout>
@@ -99,6 +105,12 @@
    <header>.project_selection_dialog</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>line_edit</tabstop>
+  <tabstop>project_list</tabstop>
+  <tabstop>open_project_btn</tabstop>
+  <tabstop>new_project_btn</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/Mergin/ui/ui_select_project_dialog.ui
+++ b/Mergin/ui/ui_select_project_dialog.ui
@@ -14,17 +14,43 @@
    <string>Find project</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0">
+   <item row="6" column="0">
     <widget class="ProjectListView" name="project_list"/>
    </item>
-   <item row="2" column="0">
+   <item row="8" column="0">
+    <widget class="QLabel" name="switch_workspace_label">
+     <property name="text">
+      <string>Looking for a project from a different workspace? &lt;a href=&quot;null&quot;&gt;Click here to switch workspace&lt;/a&gt;</string>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextBrowserInteraction</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QPushButton" name="new_project_btn">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Create new project</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Select a project to work with</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" alignment="Qt::AlignHCenter">
+   <item row="7" column="0" alignment="Qt::AlignHCenter">
     <widget class="QPushButton" name="open_project_btn">
      <property name="minimumSize">
       <size>
@@ -46,9 +72,9 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
+   <item row="1" column="0" alignment="Qt::AlignHCenter">
     <widget class="QLabel" name="label_logo">
-     <property name="minimumSize">
+     <property name="maximumSize">
       <size>
        <width>256</width>
        <height>76</height>
@@ -57,39 +83,16 @@
      <property name="text">
       <string>mmLabel</string>
      </property>
+     <property name="scaledContents">
+      <bool>true</bool>
+     </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="switch_workspace_label">
-     <property name="text">
-      <string>Looking for a project from a different workspace? &lt;a href=&quot;null&quot;&gt;Click here to switch workspace&lt;/a&gt;</string>
-     </property>
-     <property name="textInteractionFlags">
-      <set>Qt::TextBrowserInteraction</set>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
+   <item row="5" column="0">
     <widget class="QgsFilterLineEdit" name="line_edit"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QPushButton" name="new_project_btn">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Create new project</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/Mergin/ui/ui_select_project_dialog.ui
+++ b/Mergin/ui/ui_select_project_dialog.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="4" column="0">
-    <widget class="QListView" name="project_list"/>
+    <widget class="ProjectListView" name="project_list"/>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label">
@@ -60,9 +60,12 @@
     </widget>
    </item>
    <item row="6" column="0">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="switch_workspace_label">
      <property name="text">
-      <string>Looking for a project from a different workspace? Click here to switch workspace</string>
+      <string>Looking for a project from a different workspace? &lt;a href=&quot;null&quot;&gt;Click here to switch workspace&lt;/a&gt;</string>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextBrowserInteraction</set>
      </property>
     </widget>
    </item>
@@ -89,6 +92,11 @@
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgsfilterlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ProjectListView</class>
+   <extends>QListView</extends>
+   <header>.project_selection_dialog</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/Mergin/ui/ui_select_project_dialog.ui
+++ b/Mergin/ui/ui_select_project_dialog.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="6" column="0">
-    <widget class="ProjectListView" name="project_list"/>
+    <widget class="QListView" name="project_list"/>
    </item>
    <item row="8" column="0">
     <widget class="QLabel" name="switch_workspace_label">
@@ -101,11 +101,6 @@
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgsfilterlineedit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>ProjectListView</class>
-   <extends>QListView</extends>
-   <header>.project_selection_dialog</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/Mergin/ui/ui_select_project_dialog.ui
+++ b/Mergin/ui/ui_select_project_dialog.ui
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>393</width>
+    <height>432</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="4" column="0">
+    <widget class="QListView" name="project_list"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Select a project to work with</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" alignment="Qt::AlignHCenter">
+    <widget class="QPushButton" name="open_project_btn">
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>200</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Open project</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_logo">
+     <property name="minimumSize">
+      <size>
+       <width>256</width>
+       <height>76</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>mmLabel</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Looking for a project from a different workspace? Click here to switch workspace</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QgsFilterLineEdit" name="line_edit"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QPushButton" name="new_project_btn">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Create new project</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1259,3 +1259,11 @@ def package_datum_grids(dest_dir):
     if dest_dir is not None:
         os.makedirs(dest_dir, exist_ok=True)
         copy_datum_shift_grids(dest_dir)
+
+
+def compare_versions(first, second):
+    """
+    Compares two version strings and returns an integer less than, equal to,
+    or greater than zero if first is less than, equal to, or greater than second.
+    """
+    return int(first[1:]) - int(second[1:])


### PR DESCRIPTION
Added _Find project_ and _Explore public projects_ dialogs, accessible via the browser's context menus.

For EE/CE:
![image](https://user-images.githubusercontent.com/11358178/199448918-dcc60155-ab97-4a4c-b3db-17305eaae750.png)

For old servers:
![image](https://user-images.githubusercontent.com/11358178/199449107-88f5b062-770b-4d1f-87c9-739608655ab4.png)

Find projects looks like this:
![image](https://user-images.githubusercontent.com/11358178/199457715-6ca3038d-9c07-4a32-9427-e44002706a15.png)

The switch workspaces text is only visible is there are more workspaces available.



Explore public projects looks like this:
![image](https://user-images.githubusercontent.com/11358178/199457904-4d2a0b33-2ca3-4ce6-b512-57280d7af1d3.png)
