### PR TITLE
Workspaces QA fixes

### DIFF
--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -904,14 +904,20 @@ class MerginRootItem(QgsDataCollectionItem):
             sip.transferto(error_item, self)
             return [error_item]
         try:
-            resp = self.project_manager.mc.paginated_projects_list(
-                flag=self.filter,
-                only_namespace=None if self.filter else self.plugin.current_workspace.get("name", None),
-                page=page,
-                per_page=per_page,
-                # todo: switch back to "namespace_asc,name_asc" as it currently crashes ee.dev and ce.dev
-                order_params="name_asc",
-            )
+            if self.mc.server_type() == ServerType.OLD:
+                resp = self.project_manager.mc.paginated_projects_list(
+                    flag=self.filter,
+                    page=page,
+                    per_page=per_page,
+                    order_params="namespace_asc,name_asc",
+                )
+            else:
+                resp = self.project_manager.mc.paginated_projects_list(
+                    only_namespace=self.plugin.current_workspace.get("name", None),
+                    page=page,
+                    per_page=per_page,
+                    order_params="name_asc",
+                )
             self.projects += resp["projects"]
             self.total_projects_count = int(resp["count"]) if is_number(resp["count"]) else 0
         except URLError:

--- a/Mergin/project_selection_dialog.py
+++ b/Mergin/project_selection_dialog.py
@@ -16,9 +16,7 @@ from qgis.PyQt.QtCore import (
 )
 from qgis.PyQt import uic
 from qgis.PyQt.QtGui import QPixmap, QFont, QFontMetrics, QIcon, QStandardItem, QStandardItemModel
-from qgis.core import (
-    QgsApplication,
-)
+
 from .mergin.client import MerginProject, InvalidProject
 from .utils import (
     icon_path,
@@ -279,12 +277,12 @@ class ProjectSelectionDialog(QDialog):
             else:
                 # Let's replace the existing request with the new one
                 self.fetcher.requestInterruption()
-                QgsApplication.instance().restoreOverrideCursor()
+                self.ui.line_edit.setShowSpinner(False)
 
         self.current_search_term = self.ui.line_edit.text()
         self.fetcher = ResultFetcher(self.mc, self.current_workspace_name, self.request_page, self.current_search_term)
         self.fetcher.finished.connect(self.handle_server_response)
-        QgsApplication.instance().setOverrideCursor(Qt.WaitCursor)
+        self.ui.line_edit.setShowSpinner(True)
         self.fetcher.start()
 
     def handle_server_response(self, projects):
@@ -300,7 +298,7 @@ class ProjectSelectionDialog(QDialog):
             self.model.appendProjects(projects["projects"])
         except KeyError:
             pass
-        QgsApplication.instance().restoreOverrideCursor()
+        self.ui.line_edit.setShowSpinner(False)
 
     def on_scrollbar_changed(self, value):
         if not self.need_to_fetch_next_page:


### PR DESCRIPTION
- Handles an exception caused by a broken local project
- Use newest api for paginated results (`only_public=true`, `order_params=workspaces_asc`)
- Use QgsFilterLineEdit.setShowSpinner() instead of global cursor override while fetching results. It adds the spinner to the right end of the line edit widget and looks like this:

https://user-images.githubusercontent.com/11358178/215084035-a0551f69-b481-41a6-b202-b2c8ca1e5f6d.mp4

