### PR TITLE
Expression-based names for photos

### DIFF
--- a/Mergin/attachment_fields_model.py
+++ b/Mergin/attachment_fields_model.py
@@ -25,9 +25,6 @@ class AttachmentFieldsModel(QStandardItemModel):
                 if widget_setup.type() != "ExternalResource":
                     continue
 
-                if not widget_setup.config().get("DocumentViewer", 1):
-                    continue
-
                 item_layer = QStandardItem(f"{layer.name()}")
                 if layer.renderer().type() == "singleSymbol":
                     icon = QgsSymbolLayerUtils.symbolPreviewIcon(layer.renderer().symbol(), QSize(16, 16))

--- a/Mergin/attachment_fields_model.py
+++ b/Mergin/attachment_fields_model.py
@@ -1,6 +1,6 @@
 from qgis.PyQt.QtGui import QStandardItemModel, QStandardItem
-from qgis.PyQt.QtCore import Qt
-from qgis.core import QgsProject, QgsMapLayer
+from qgis.PyQt.QtCore import Qt, QSize
+from qgis.core import QgsProject, QgsMapLayer, QgsSymbolLayerUtils, QgsIconUtils
 
 
 class AttachmentFieldsModel(QStandardItemModel):
@@ -29,6 +29,12 @@ class AttachmentFieldsModel(QStandardItemModel):
                     continue
 
                 item_layer = QStandardItem(f"{layer.name()}")
+                if layer.renderer().type() == "singleSymbol":
+                    icon = QgsSymbolLayerUtils.symbolPreviewIcon(layer.renderer().symbol(), QSize(16, 16))
+                    item_layer.setIcon(icon)
+                else:
+                    item_layer.setIcon(QgsIconUtils.iconForLayer(layer))
+
                 item_field = QStandardItem(f"{field.name()}")
                 item_field.setData(layer_id, AttachmentFieldsModel.LAYER_ID)
                 item_field.setData(field.name(), AttachmentFieldsModel.FIELD_NAME)

--- a/Mergin/attachment_fields_model.py
+++ b/Mergin/attachment_fields_model.py
@@ -11,6 +11,10 @@ class AttachmentFieldsModel(QStandardItemModel):
     def __init__(self, parent=None):
         super().__init__(parent)
 
+        self.setHorizontalHeaderLabels(["Layer", "Field"])
+
+        parent_item = self.invisibleRootItem()
+
         layers = QgsProject.instance().mapLayers()
         for layer_id, layer in layers.items():
             if layer.type() != QgsMapLayer.VectorLayer:
@@ -24,9 +28,10 @@ class AttachmentFieldsModel(QStandardItemModel):
                 if not widget_setup.config().get("DocumentViewer", 1):
                     continue
 
-                item = QStandardItem(f"{layer.name()} - {field.name()}")
-                item.setData(layer_id, AttachmentFieldsModel.LAYER_ID)
-                item.setData(field.name(), AttachmentFieldsModel.FIELD_NAME)
+                item_layer = QStandardItem(f"{layer.name()}")
+                item_field = QStandardItem(f"{field.name()}")
+                item_field.setData(layer_id, AttachmentFieldsModel.LAYER_ID)
+                item_field.setData(field.name(), AttachmentFieldsModel.FIELD_NAME)
                 exp, ok = QgsProject.instance().readEntry("Mergin", f"PhotoNaming/{layer_id}/{field.name()}")
-                item.setData(exp, AttachmentFieldsModel.EXPRESSION)
-                self.appendRow(item)
+                item_field.setData(exp, AttachmentFieldsModel.EXPRESSION)
+                parent_item.appendRow([item_layer, item_field])

--- a/Mergin/attachment_fields_model.py
+++ b/Mergin/attachment_fields_model.py
@@ -1,0 +1,33 @@
+from qgis.PyQt.QtGui import QStandardItemModel, QStandardItem
+from qgis.PyQt.QtCore import Qt
+from qgis.core import QgsProject, QgsMapLayer
+
+
+class AttachmentFieldsModel(QStandardItemModel):
+
+    LAYER_ID = Qt.UserRole + 1
+    FIELD_NAME = Qt.UserRole + 2
+    EXPRESSION = Qt.UserRole + 3
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        layers = QgsProject.instance().mapLayers()
+        for layer_id, layer in layers.items():
+            if layer.type() != QgsMapLayer.VectorLayer:
+                continue
+
+            for field in layer.fields():
+                widget_setup = field.editorWidgetSetup()
+                if widget_setup.type() != "ExternalResource":
+                    continue
+
+                if not widget_setup.config().get("DocumentViewer", 1):
+                    continue
+
+                item = QStandardItem(f"{layer.name()} - {field.name()}")
+                item.setData(layer_id, AttachmentFieldsModel.LAYER_ID)
+                item.setData(field.name(), AttachmentFieldsModel.FIELD_NAME)
+                exp, ok = QgsProject.instance().readEntry("Mergin", f"PhotoNaming/{layer_id}/{field.name()}")
+                item.setData(exp, AttachmentFieldsModel.EXPRESSION)
+                self.appendRow(item)

--- a/Mergin/attachment_fields_model.py
+++ b/Mergin/attachment_fields_model.py
@@ -4,7 +4,6 @@ from qgis.core import QgsProject, QgsMapLayer
 
 
 class AttachmentFieldsModel(QStandardItemModel):
-
     LAYER_ID = Qt.UserRole + 1
     FIELD_NAME = Qt.UserRole + 2
     EXPRESSION = Qt.UserRole + 3

--- a/Mergin/project_settings_widget.py
+++ b/Mergin/project_settings_widget.py
@@ -64,9 +64,9 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
         else:
             self.selective_sync_group.setEnabled(False)
 
-        self.model = AttachmentFieldsModel()
-        self.tree_fields.setModel(self.model)
-        self.tree_fields.selectionModel().currentChanged.connect(self.update_expression_edit)
+        self.attachments_model = AttachmentFieldsModel()
+        self.attachment_fields.setModel(self.attachments_model)
+        self.attachment_fields.selectionModel().currentChanged.connect(self.update_expression_edit)
         self.edit_photo_expression.expressionChanged.connect(self.expression_changed)
 
     def get_sync_dir(self):
@@ -104,19 +104,19 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
             json.dump(config, f, indent=2)
 
     def expression_changed(self, expression):
-        if not self.tree_fields.selectionModel().hasSelection():
+        if not self.attachment_fields.selectionModel().hasSelection():
             return
-        index = self.tree_fields.selectionModel().selectedIndexes()[0]
+        index = self.attachment_fields.selectionModel().selectedIndexes()[0]
         layer = None
         if index.isValid():
-            item = self.model.item(index.row(), 1)
+            item = self.attachments_model.item(index.row(), 1)
             item.setData(self.edit_photo_expression.expression(), AttachmentFieldsModel.EXPRESSION)
             layer = QgsProject.instance().mapLayer(item.data(AttachmentFieldsModel.LAYER_ID))
 
         self.update_preview(expression, layer)
 
     def update_expression_edit(self, current, previous):
-        item = self.model.item(current.row(), 1)
+        item = self.attachments_model.item(current.row(), 1)
         exp = item.data(AttachmentFieldsModel.EXPRESSION)
         layer = QgsProject.instance().mapLayer(item.data(AttachmentFieldsModel.LAYER_ID))
         if layer and layer.isValid():
@@ -161,7 +161,7 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
         for i in range(self.model.rowCount()):
             index = self.model.index(i, 1)
             if index.isValid():
-                item = self.model.itemFromIndex(index)
+                item = self.attachments_model.itemFromIndex(index)
                 layer_id = item.data(AttachmentFieldsModel.LAYER_ID)
                 field_name = item.data(AttachmentFieldsModel.FIELD_NAME)
                 expression = item.data(AttachmentFieldsModel.EXPRESSION)

--- a/Mergin/project_settings_widget.py
+++ b/Mergin/project_settings_widget.py
@@ -58,8 +58,8 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
             self.selective_sync_group.setEnabled(False)
 
         self.model = AttachmentFieldsModel()
-        self.list_fields.setModel(self.model)
-        self.list_fields.selectionModel().currentChanged.connect(self.update_expression_edit)
+        self.tree_fields.setModel(self.model)
+        self.tree_fields.selectionModel().currentChanged.connect(self.update_expression_edit)
         self.edit_photo_expression.expressionChanged.connect(self.save_expression)
 
     def get_sync_dir(self):
@@ -97,15 +97,15 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
             json.dump(config, f, indent=2)
 
     def save_expression(self, expression):
-        if not self.list_fields.selectionModel().hasSelection():
+        if not self.tree_fields.selectionModel().hasSelection():
             return
-        index = self.list_fields.selectionModel().selectedIndexes()[0]
+        index = self.tree_fields.selectionModel().selectedIndexes()[0]
         if index.isValid():
-            item = self.model.itemFromIndex(index)
+            item = self.model.item(index.row(), 1)
             item.setData(self.edit_photo_expression.expression(), AttachmentFieldsModel.EXPRESSION)
 
     def update_expression_edit(self, current, previous):
-        item = self.model.itemFromIndex(current)
+        item = self.model.item(current.row(), 1)
         exp = item.data(AttachmentFieldsModel.EXPRESSION)
         layer_id = item.data(AttachmentFieldsModel.LAYER_ID)
         layer = QgsProject.instance().mapLayer(layer_id)
@@ -120,7 +120,7 @@ class ProjectConfigWidget(ProjectConfigUiWidget, QgsOptionsPageWidget):
         QgsProject.instance().writeEntry("Mergin", "PhotoQuality", self.cmb_photo_quality.currentData())
         QgsProject.instance().writeEntry("Mergin", "Snapping", self.cmb_snapping_mode.currentData())
         for i in range(self.model.rowCount()):
-            index = self.model.index(i, 0)
+            index = self.model.index(i, 1)
             if index.isValid():
                 item = self.model.itemFromIndex(index)
                 layer_id = item.data(AttachmentFieldsModel.LAYER_ID)

--- a/Mergin/test/test_help.py
+++ b/Mergin/test/test_help.py
@@ -12,7 +12,6 @@ test_data_path = os.path.join(os.path.dirname(__file__), "data")
 class test_help(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
         start_app()
 
     def test_help_urls(self):

--- a/Mergin/test/test_packaging.py
+++ b/Mergin/test/test_packaging.py
@@ -14,7 +14,6 @@ test_data_path = os.path.join(os.path.dirname(__file__), "data")
 class test_packaging(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
         start_app()
 
     def test_copy_raster(self):

--- a/Mergin/test/test_utils.py
+++ b/Mergin/test/test_utils.py
@@ -21,7 +21,6 @@ test_data_path = os.path.join(os.path.dirname(__file__), "data")
 class test_utils(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
         start_app()
 
     def tearDown(self):

--- a/Mergin/test/test_validations.py
+++ b/Mergin/test/test_validations.py
@@ -15,7 +15,6 @@ test_data_path = os.path.join(os.path.dirname(__file__), "data")
 class test_validations(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
         start_app()
 
     def tearDown(self):

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -165,6 +165,19 @@
       <string>Photo attachment</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_5">
+      <item row="2" column="1">
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
       <item row="1" column="1">
        <widget class="QLabel" name="label_6">
         <property name="text">
@@ -181,28 +194,8 @@
       <item row="0" column="1">
        <widget class="QgsExpressionLineEdit" name="edit_photo_expression" native="true"/>
       </item>
-      <item row="2" column="1">
-       <spacer name="verticalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="0" column="0" rowspan="3">
-       <widget class="QListView" name="list_fields">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
+      <item row="0" column="0" rowspan="4">
+       <widget class="QTreeView" name="tree_fields"/>
       </item>
      </layout>
     </widget>
@@ -223,7 +216,6 @@
   <tabstop>btn_get_sync_dir</tabstop>
   <tabstop>cmb_photo_quality</tabstop>
   <tabstop>cmb_snapping_mode</tabstop>
-  <tabstop>list_fields</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -166,7 +166,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_5">
       <item row="0" column="0" rowspan="5">
-       <widget class="QTreeView" name="tree_fields">
+       <widget class="QTreeView" name="attachment_fields">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
           <horstretch>0</horstretch>

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>535</width>
-    <height>516</height>
+    <height>615</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -165,20 +165,34 @@
       <string>Photo attachment</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_5">
-      <item row="2" column="1">
-       <spacer name="verticalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
+      <item row="0" column="0" rowspan="5">
+       <widget class="QTreeView" name="tree_fields">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
+       </widget>
       </item>
       <item row="1" column="1">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Preview</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="label_preview">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QgsExpressionLineEdit" name="edit_photo_expression" native="true"/>
+      </item>
+      <item row="2" column="1" colspan="2">
        <widget class="QLabel" name="label_6">
         <property name="text">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -191,11 +205,18 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QgsExpressionLineEdit" name="edit_photo_expression" native="true"/>
-      </item>
-      <item row="0" column="0" rowspan="4">
-       <widget class="QTreeView" name="tree_fields"/>
+      <item row="3" column="1" colspan="2">
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>
@@ -206,7 +227,7 @@
   <customwidget>
    <class>QgsExpressionLineEdit</class>
    <extends>QWidget</extends>
-   <header>qgis.gui</header>
+   <header>qgsexpressionlineedit.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>495</width>
-    <height>367</height>
+    <width>535</width>
+    <height>516</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -82,19 +82,6 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="1" column="0" colspan="2">
     <widget class="QGroupBox" name="photo_quality_groupbox">
      <property name="title">
@@ -126,6 +113,19 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item row="2" column="0" colspan="2">
     <widget class="QGroupBox" name="snapping_group_box">
@@ -159,8 +159,72 @@
      </layout>
     </widget>
    </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Photo attachment</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="1" column="1">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QgsExpressionLineEdit" name="edit_photo_expression" native="true"/>
+      </item>
+      <item row="2" column="1">
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="0" rowspan="3">
+       <widget class="QListView" name="list_fields">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsExpressionLineEdit</class>
+   <extends>QWidget</extends>
+   <header>qgis.gui</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>chk_sync_enabled</tabstop>
+  <tabstop>edit_sync_dir</tabstop>
+  <tabstop>btn_get_sync_dir</tabstop>
+  <tabstop>cmb_photo_quality</tabstop>
+  <tabstop>cmb_snapping_mode</tabstop>
+  <tabstop>list_fields</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/Mergin/ui/ui_project_config.ui
+++ b/Mergin/ui/ui_project_config.ui
@@ -9,14 +9,149 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>535</width>
-    <height>615</height>
+    <width>638</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Create Mergin Project</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
+   <item row="1" column="0" colspan="2">
+    <widget class="QGroupBox" name="photo_quality_groupbox">
+     <property name="title">
+      <string>Photo quality</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Photo quality</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="cmb_photo_quality"/>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option is used by Mergin Maps Input when adding pictures to the project (taken from camera or using existing picture from gallery).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QGroupBox" name="snapping_group_box">
+     <property name="title">
+      <string>Snapping</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="1" column="1">
+       <widget class="QComboBox" name="cmb_snapping_mode"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Snapping settings</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By allowing snapping here, Mergin Maps Input will use snapping for this project. Learn more in the &lt;a href=&quot;https://merginmaps.com/docs/gis/snapping/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Photo attachments configuration</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="4" column="2">
+       <widget class="QLabel" name="label_preview">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" rowspan="8">
+       <widget class="QTreeView" name="attachment_fields">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="rootIsDecorated">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Preview</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="2">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;strong&gt;Photo name format&lt;/strong&gt;&lt;/p&gt;&lt;p&gt;Set up custom photo names format based on an expression. Make sure that the name is unique for each photo.&lt;/p&gt;&lt;p&gt;Pro tip: use variables like &lt;code&gt;@mergin_username&lt;/code&gt;, &lt;code&gt;@layer_name&lt;/code&gt; or layer fields in combination with &lt;code&gt;now()&lt;/code&gt; (to get the current time) in order to generate unique photo names.&lt;/p&gt;&lt;p&gt;For further details, please refer to &lt;a href=&quot;https://merginmaps.com/docs/layer/settingup_forms_photo/#customising-photo-name-format-with-expressions&quot;&gt;our documentation&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="2">
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="3" column="1" colspan="2">
+       <widget class="QgsExpressionLineEdit" name="edit_photo_expression" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="0" column="0" colspan="2">
     <widget class="QGroupBox" name="selective_sync_group">
      <property name="title">
@@ -82,39 +217,7 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QGroupBox" name="photo_quality_groupbox">
-     <property name="title">
-      <string>Photo quality</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Photo quality</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="cmb_photo_quality"/>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option is used by Mergin Maps Input when adding pictures to the project (taken from camera or using existing picture from gallery).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="openExternalLinks">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -126,100 +229,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QGroupBox" name="snapping_group_box">
-     <property name="title">
-      <string>Snapping</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <item row="1" column="1">
-       <widget class="QComboBox" name="cmb_snapping_mode"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Snapping settings</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;By allowing snapping here, Mergin Maps Input will use snapping for this project. Learn more in the &lt;a href=&quot;https://merginmaps.com/docs/gis/snapping/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;documentation&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="openExternalLinks">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Photo attachment</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_5">
-      <item row="0" column="0" rowspan="5">
-       <widget class="QTreeView" name="attachment_fields">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>Preview</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QLabel" name="label_preview">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QgsExpressionLineEdit" name="edit_photo_expression" native="true"/>
-      </item>
-      <item row="2" column="1" colspan="2">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-        <property name="openExternalLinks">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1" colspan="2">
-       <spacer name="verticalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -790,11 +790,7 @@ def update_datasource(layer, new_path):
     """Updates layer datasource, so the layer is loaded from the new location"""
     options = QgsDataProvider.ProviderOptions()
     options.layerName = layer.name()
-    if layer.dataProvider().name() == "mbtilesvectortiles":
-        # For 3.31 and master
-        layer.setDataSource(f"url={new_path}&type=mbtiles", layer.name(), layer.dataProvider().name(), options)
-    elif layer.dataProvider().name() == "vectortile":
-        # For 3.22
+    if layer.dataProvider().name() == "vectortile":
         layer.setDataSource(f"url={new_path}&type=mbtiles", layer.name(), layer.dataProvider().name(), options)
     elif layer.dataProvider().name() == "wms":
         layer.setDataSource(f"url=file://{new_path}&type=mbtiles", layer.name(), layer.dataProvider().name(), options)

--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -47,6 +47,9 @@ from qgis.core import (
     QgsProjUtils,
     QgsDataSourceUri,
     QgsVectorTileLayer,
+    QgsFeature,
+    QgsFeatureRequest,
+    QgsExpression,
 )
 
 from .mergin.utils import int_version
@@ -1298,3 +1301,59 @@ def is_valid_name(name):
         )
         is None
     )
+
+
+def resolve_target_dir(layer, widget_config):
+    """
+    Evaluates the "default path" for attachment widget. The following order is used:
+     - evaluate default path expression if defined,
+     - use default path value if not empty,
+     - use project home folder
+    """
+    project_home = QgsProject.instance().homePath()
+    collection = widget_config.get("PropertyCollection")
+    props = None
+    if collection:
+        props = collection.get("properties")
+
+    expression = None
+    if props:
+        root_path = props.get("propertyRootPath")
+        expression = root_path.get("expression")
+
+    if expression:
+        return evaluate_expression(expression, layer)
+
+    default_root = widget_config.get("DefaultRoot")
+    return default_root if default_root else project_home
+
+
+def evaluate_expression(expression, layer):
+    """
+    Evaluates expression, layer is used to define expression context scopes
+    and get a feature.
+    """
+    context = layer.createExpressionContext()
+    f = QgsFeature()
+    layer.getFeatures(QgsFeatureRequest().setLimit(1)).nextFeature(f)
+    if f.isValid():
+        context.setFeature(f)
+
+    exp = QgsExpression(expression)
+    return exp.evaluate(context)
+
+
+def prefix_for_relative_path(mode, home_path, target_dir):
+    """
+    Resolves path of an image for a field with ExternalResource widget type.
+    Returns prefix which has to be added to the field's value to obtain working path to load the image.
+    param relativeStorageMode: storage mode used by the widget
+    param home_path: project path
+    param target_dir: default path in the widget configuration
+    """
+    if mode == 1:  # relative to project
+        return home_path
+    elif mode == 2:  # relative to defaultRoot defined in the widget config
+        return target_dir
+    else:
+        return ""


### PR DESCRIPTION
Add UI to configure expression-based photo names to the project properties dialog. If expression for a field is set, Input will use it to rename photos.
![image](https://github.com/MerginMaps/qgis-mergin-plugin/assets/776954/7047d901-6176-448d-8271-6b4c9d9b2983)


