### PR TITLE
ask user to type project name to confirm its removal from the server (fix #128)

### DIFF
--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -659,10 +659,6 @@ class MerginRemoteProjectItem(QgsDataItem):
         dlg = RemoveProjectDialog(self.project_name)
         if dlg.exec_() == QDialog.Rejected:
             return
-        # ~ msg = "Do you really want to remove project {} from server?".format(self.project_name)
-        # ~ btn_reply = QMessageBox.question(None, "Remove project", msg, QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
-        # ~ if btn_reply == QMessageBox.No:
-        # ~ return
 
         try:
             self.mc.delete_project(self.project_name)

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -514,7 +514,7 @@ class MerginPlugin:
             self.enable_toolbar_actions()
 
     def add_context_menu_actions(self, layers):
-        provider_names = ("vectortile")
+        provider_names = "vectortile"
         if Qgis.versionInt() >= 33200:
             provider_names = ("xyzvectortiles", "arcgisvectortileservice", "vtpkvectortiles")
         for l in layers:

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -12,6 +12,7 @@ import posixpath
 from functools import partial
 from qgis.PyQt.QtCore import pyqtSignal, QTimer, QUrl, QSettings, Qt
 from qgis.PyQt.QtGui import QIcon, QDesktopServices, QPixmap
+from qgis.PyQt.QtWidgets import QDialog
 from qgis.core import (
     QgsApplication,
     QgsDataCollectionItem,
@@ -40,6 +41,7 @@ from .project_settings_widget import MerginProjectConfigFactory
 from .projects_manager import MerginProjectsManager
 from .sync_dialog import SyncDialog
 from .configure_sync_wizard import DbSyncConfigWizard
+from .remove_project_dialog import RemoveProjectDialog
 from .utils import (
     ServerType,
     ClientError,
@@ -654,10 +656,13 @@ class MerginRemoteProjectItem(QgsDataItem):
             group_items["My projects"].reload()
 
     def remove_remote_project(self):
-        msg = "Do you really want to remove project {} from server?".format(self.project_name)
-        btn_reply = QMessageBox.question(None, "Remove project", msg, QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
-        if btn_reply == QMessageBox.No:
+        dlg = RemoveProjectDialog(self.project_name)
+        if dlg.exec_() == QDialog.Rejected:
             return
+        # ~ msg = "Do you really want to remove project {} from server?".format(self.project_name)
+        # ~ btn_reply = QMessageBox.question(None, "Remove project", msg, QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+        # ~ if btn_reply == QMessageBox.No:
+        # ~ return
 
         try:
             self.mc.delete_project(self.project_name)

--- a/Mergin/remove_project_dialog.py
+++ b/Mergin/remove_project_dialog.py
@@ -1,0 +1,25 @@
+import os
+
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox
+
+ui_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "ui", "ui_remove_project_dialog.ui")
+
+
+class RemoveProjectDialog(QDialog):
+    def __init__(self, project_name, parent=None):
+        QDialog.__init__(self, parent)
+        self.ui = uic.loadUi(ui_file, self)
+
+        self.project_name = project_name
+        self.label.setText(
+            f"This action will remove your MerginMaps project '<b>{self.project_name}</b>' from the server. "
+            "This action cannot be undone.<br><br>"
+            "In order to delete project, enter project name in the field below and click 'Yes'."
+        )
+        self.buttonBox.button(QDialogButtonBox.Yes).setEnabled(False)
+
+        self.edit_project_name.textChanged.connect(self.project_name_changed)
+
+    def project_name_changed(self, text):
+        self.buttonBox.button(QDialogButtonBox.Yes).setEnabled(self.project_name == text)

--- a/Mergin/ui/ui_remove_project_dialog.ui
+++ b/Mergin/ui/ui_remove_project_dialog.ui
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>152</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Remove project</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>This action will remove your MerginMaps project from the server. This action cannot be undone.
+
+In order to delete project, enter project name in the field below and click &quot;Yes&quot;.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="edit_project_name">
+     <property name="placeholderText">
+      <string>Enter project name</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::No|QDialogButtonBox::Yes</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Replace simple question message box with a custom dialog where user needs to enter project name to comfirm its removal from the server
![image](https://github.com/MerginMaps/qgis-mergin-plugin/assets/776954/e1a5ed6b-88fd-4034-9ab6-11659baf632e)

Fixes #128.