### PR TITLE
show error message when trying to get status of removed project (fix #263)

### DIFF
--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -155,13 +155,14 @@ class MerginProjectsManager(object):
         if check_result == UnsavedChangesStrategy.HasUnsavedChanges:
             return
 
-        mp = MerginProject(project_dir)
         try:
+            mp = MerginProject(project_dir)
             project_name = mp.metadata["name"]
         except InvalidProject as e:
             msg = f"Failed to get project status:\n\n{str(e)}"
             QMessageBox.critical(None, "Project status", msg, QMessageBox.Close)
             return
+
         if not self.check_project_server(project_dir):
             return
         try:


### PR DESCRIPTION
If project removed manually (outside of QGIS) an attempt to check project status results in a Python error. Better to catch an exception and show more friendly error dialog.

Fixes #263.