### PR TITLE
Fix unreported : Fix crash with f string expression

### DIFF
--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -101,7 +101,7 @@ class MerginProjectsManager(object):
                 )
             elif e.server_code == ErrorCode.StorageLimitHit.value:
                 msg = (
-                    f"{e.detail}]\nCurrent limit: {bytes_to_human_size(dlg.exception.server_response["storage_limit"])}"
+                    f"{e.detail}\nCurrent limit: {bytes_to_human_size(dlg.exception.server_response['storage_limit'])}"
                 )
 
             QMessageBox.critical(None, "Create Project", "Failed to create Mergin Maps project.\n" + msg)
@@ -375,7 +375,7 @@ class MerginProjectsManager(object):
                     # To note we check for a string since error in flask doesn't return server error code
                     msg = "Somebody else is syncing, please try again later"
                 elif dlg.exception.server_code == ErrorCode.StorageLimitHit.value:
-                    msg = f"{e.detail}]\nCurrent limit: {bytes_to_human_size(dlg.exception.server_response["storage_limit"])}"
+                    msg = f"{e.detail}\nCurrent limit: {bytes_to_human_size(dlg.exception.server_response['storage_limit'])}"
                 else:
                     msg = str(dlg.exception)
                 QMessageBox.critical(None, "Project sync", "Client error: \n" + msg)


### PR DESCRIPTION
In some older python version, f string are confused when using the string delimiter inside the expression. That makes crash the plugin on installs

This PR fix the issues by using a mix of simple and double quote