### PR TITLE
Fix crash when attempting to connect or test connect while the field for custom server url was empty

### DIFF
--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1247,7 +1247,7 @@ def test_server_connection(url, username, password):
                 "Deprecated server version",
                 "This server is running an outdated version that will no longer be supported. Please contact your server administrator to upgrade.",
             )
-    except (LoginError, ClientError) as e:
+    except (LoginError, ClientError, ValueError) as e:
         QgsApplication.messageLog().logMessage(f"Mergin Maps plugin: {str(e)}")
         result = False, f"<font color=red> Connection failed, {str(e)} </font>"
 


### PR DESCRIPTION
Fix hard crash when attempting to connect or test connect while the field for custom server url was empty

![Screenshot From 2025-06-25 09-11-51](https://github.com/user-attachments/assets/d1a941a7-4b8b-4674-a8ff-27115b880dc2)

Now it's display next to test connection even if the message could be a little more explicit


![Screenshot From 2025-06-25 09-11-12](https://github.com/user-attachments/assets/577c91f6-0057-4817-8e4b-6f27ee5abcbd)
