### PR TITLE
Fix projects list reloading

### DIFF
--- a/Mergin/data_item.py
+++ b/Mergin/data_item.py
@@ -443,15 +443,6 @@ class MerginRootItem(QgsDataCollectionItem):
             self.projects += resp["projects"]
             self.total_projects_count = int(resp["count"]) if is_number(resp["count"]) else 0
 
-            # Sometimes we fetched a local, recursivly fetch until we fetched enougth at the same time
-            set_fetched_projects = set([i["name"] for i in resp["projects"]])
-            set_local_projects = set([i["name"] for i in self.local_projects])
-
-            new_projs_per_page_left = per_page - len(set_fetched_projects - set_local_projects)
-            if new_projs_per_page_left != 0 and len(self.projects) < self.total_projects_count:
-                new_page_to_get = floor(len(self.projects) / new_projs_per_page_left) + 1
-                self.fetch_projects(new_page_to_get, per_page=new_projs_per_page_left)
-
         except URLError:
             error_item = QgsErrorItem(self, "Failed to get projects from server", "/Mergin/error")
             sip.transferto(error_item, self)


### PR DESCRIPTION
Fixes https://github.com/MerginMaps/qgis-plugin/pull/735#issuecomment-3234494770

I don't see the benefit of this recursive loading. It breaks the `set_fetch_more_item` method.