### PR TITLE
Fix crash on project creation when workspace project limit reached (s…

### DIFF
--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -116,7 +116,7 @@ class MerginProjectsManager(object):
                     if isinstance(data, str):
                         try:
                             data = json.loads(data)  # convert string to json
-                        except Exception:
+                        except json.JSONDecodeError:
                             data = {}
 
                     quota = data.get("projects_quota", "unknown")


### PR DESCRIPTION
Fixed crash when creating a project in a workspace that reached its limit.
server_response was a JSON string, not a dict, so accessing keys caused a TypeError.
Now it’s safely parsed with json.loads() and shows a proper “workspace limit reached” message instead of crashing.

<img width="571" height="178" alt="image" src="https://github.com/user-attachments/assets/4039a16f-8a9e-470e-b603-229c145c66d3" />


fixes #825 