### PR TITLE
Fix .mergin detection to avoid scanning subdirectories

### DIFF
--- a/Mergin/utils.py
+++ b/Mergin/utils.py
@@ -1061,11 +1061,8 @@ def mm_symbol_path():
 
 def check_mergin_subdirs(directory):
     """Check if the directory has a Mergin Maps project subdir (.mergin)."""
-    for root, dirs, files in os.walk(directory):
-        for name in dirs:
-            if name == ".mergin":
-                return os.path.join(root, name)
-    return False
+    mergin_dir = os.path.join(directory, ".mergin")
+    return mergin_dir if os.path.isdir(mergin_dir) else False
 
 
 def is_number(s):


### PR DESCRIPTION
Stop recursive .mergin lookup (os.walk) to prevent false positives in the New Project wizard. Now checks only for .mergin directly in the selected folder, so "Use current QGIS project as is" is not incorrectly disabled.

fixes #844
