### PR TITLE
Check role first

### DIFF
--- a/Mergin/utils_auth.py
+++ b/Mergin/utils_auth.py
@@ -620,14 +620,15 @@ class AuthSync:
     def export_auth(self, client) -> None:
         """Export auth DB credentials for protected layers if they have changed"""
 
-        referenced_ids = self.get_layers_auth_ids()
-        available_ids = self.auth_mngr.configIds()
-        auth_ids = [aid for aid in referenced_ids if aid in available_ids]
-
+        # permission check - auth config .xml file can be modified from the writer role above
         project_info = client.project_info(self.mp.project_full_name())
         role = project_info.get("role")
         if not (role and role in ("writer", "owner")):
             return
+
+        referenced_ids = self.get_layers_auth_ids()
+        available_ids = self.auth_mngr.configIds()
+        auth_ids = [aid for aid in referenced_ids if aid in available_ids]
         if not auth_ids:
             if os.path.exists(self.auth_file):
                 os.remove(self.auth_file)


### PR DESCRIPTION
Fixes https://github.com/MerginMaps/qgis-plugin/issues/834#issuecomment-3811941460

Prioritize role check to ensure the editor cannot manipulate the `.xml` file.