### PR TITLE
Fix photo widget validation

### DIFF
--- a/Mergin/test/test_validations.py
+++ b/Mergin/test/test_validations.py
@@ -67,7 +67,7 @@ class test_validations(unittest.TestCase):
             "FileWidgetFilter": "",
             "PropertyCollection": {
                 "name": None,
-                "properties": {},
+                "properties": None,
                 "type": "collection",
             },
             "RelativeStorage": QgsFileWidget.RelativeStorage.Absolute,

--- a/Mergin/validation.py
+++ b/Mergin/validation.py
@@ -248,9 +248,10 @@ class MerginProjectValidator(object):
                 if ws and ws.type() == "ExternalResource":
                     cfg = ws.config()
                     field_name = field.name()
-                    properties = cfg.get("PropertyCollection", {}).get("properties", {})
-                    root_path_prop = properties.get("propertyRootPath", {})
-                    storage_url_prop = properties.get("storageUrl", {})
+                    prop_collection = cfg.get("PropertyCollection") or {}
+                    properties = prop_collection.get("properties") or {}
+                    root_path_prop = properties.get("propertyRootPath") or {}
+                    storage_url_prop = properties.get("storageUrl") or {}
 
                     is_root_active = root_path_prop.get("active", False)
                     is_storage_active = storage_url_prop.get("active", False)


### PR DESCRIPTION
Fixes https://github.com/MerginMaps/server-private/issues/3230

Core issue: `KeyError`in validations when `Data Driven Override` is `FieldBasedProperty`. When Data driven override is enabled we assume there has to be an expression. However, it is also possible to set field based override.

```
Field: 'Thumbnail_link'
------------------------------
{'DocumentViewer': 2,
 'DocumentViewerHeight': 0,
 'DocumentViewerWidth': 0,
 'FileWidget': False,
 'FileWidgetButton': True,
 'FileWidgetFilter': '',
 'FullUrl': True,
 'PropertyCollection': {'name': NULL,
                        'properties': {'propertyRootPath': {'active': True,
                                                            'expression': '"Thumbnail_link"',
                                                            'type': 3},
                                       'storageUrl': {'active': True,
                                                      'field': 'Thumbnail_link',
                                                      'type': 2}},
                        'type': 'collection'},
 'RelativeStorage': 0,
 'StorageAuthConfigId': NULL,
 'StorageMode': 0,
 'StorageType': NULL,
 'UseLink': True}
```