### PR TITLE
Fix validation warning for layers stored in project subfolders

### DIFF
--- a/Mergin/validation.py
+++ b/Mergin/validation.py
@@ -203,18 +203,24 @@ class MerginProjectValidator(object):
                 self.issues.append(SingleLayerWarning(lid, Warning.EDITABLE_NON_GPKG))
 
     def check_saved_in_proj_dir(self):
-        """Check if layers saved in project's directory."""
+        """Check if layers are stored inside the project's directory."""
         for lid, layer in self.layers.items():
             if lid not in self.layers_by_prov["gdal"] + self.layers_by_prov["ogr"]:
                 continue
+
             pub_src = layer.publicSource()
+
             if pub_src.startswith("GPKG:"):
                 pub_src = pub_src[5:]
                 l_path = pub_src[: pub_src.rfind(":")]
             else:
                 l_path = layer.publicSource().split("|")[0]
-            l_dir = os.path.dirname(l_path)
-            if not same_dir(l_dir, self.qgis_proj_dir):
+
+            # normalize path
+            l_path = os.path.abspath(l_path)
+
+            # check if layer file is inside project directory
+            if not is_inside(self.qgis_proj_dir, l_path):
                 self.issues.append(SingleLayerWarning(lid, Warning.EXTERNAL_SRC))
 
     def check_offline(self):


### PR DESCRIPTION
Validation warning when layer stored in project subfolder #883

This fixes a validation issue where layers stored in subfolders inside the project directory were incorrectly reported as being outside the project directory.

The previous implementation used `same_dir()`, which only checks if paths are identical. This change uses `is_inside()` to correctly allow layers located anywhere within the project directory hierarchy.
