### PR TITLE
Fix browser error when Mergin client is not configured

### DIFF
--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -251,7 +251,7 @@ class MerginPlugin:
             else:
                 error = "Configure the Mergin Maps plugin \nto access your projects"
         except (URLError, ClientError, LoginError):
-            error = "Plugin not configured or \nQGIS master password not set up"
+            error = "Plugin not configured or QGIS master password not set up"
         except Exception as err:
             error = "Error: {}".format(str(err))
         if error:


### PR DESCRIPTION
Solves: Python error in browser when not configured yet #888

To test this, open Settings > User Profiles > New Profile...
<img width="564" height="202" alt="image" src="https://github.com/user-attachments/assets/4c255ab9-ec67-4943-813e-76f58b16245b" />

Then install the Mergin Maps plugin and click the Mergin Maps dropdown.
<img width="312" height="73" alt="image" src="https://github.com/user-attachments/assets/c070f305-1317-4479-af3f-1c58a1fe5201" />
