### PR TITLE
Fix sqlite3 cursor and placeholder syntax in get_row_from_db (#895)

### DIFF
--- a/Mergin/diff.py
+++ b/Mergin/diff.py
@@ -75,7 +75,6 @@ def get_row_from_db(db_conn, schema_table, entry_changes):
     Fetches a single row from DB's table based on the values of pkeys
     in changeset entry
     """
-    c = db_conn.cursor()
     where_clauses = []
     query_params = []
 
@@ -88,9 +87,7 @@ def get_row_from_db(db_conn, schema_table, entry_changes):
     # We parameterize values securely; table/column names are trusted internal schema objects.
     query = 'SELECT * FROM "{}" WHERE {}'.format(schema_table.name, " AND ".join(where_clauses))  # nosec B608
 
-    c.execute(query, tuple(query_params))
-
-    return c.fetchone()
+    return db_conn.execute(query, tuple(query_params)).fetchone()
 
 
 def parse_gpkg_geom_encoding(wkb_with_gpkg_hdr):

--- a/Mergin/diff.py
+++ b/Mergin/diff.py
@@ -348,10 +348,11 @@ def make_local_changes_layer(mp, layer):
 
     fields, cols_to_fields = create_field_list(db_schema[table_name])
 
-    db_conn = None  # no ref. db
     db_conn = sqlite3.connect(base_file)
-
-    features = diff_table_to_features(diff[table_name], db_schema[table_name], fields, cols_to_fields, db_conn)
+    try:
+        features = diff_table_to_features(diff[table_name], db_schema[table_name], fields, cols_to_fields, db_conn)
+    finally:
+        db_conn.close()
 
     # create diff layer
     vl = QgsVectorLayer(
@@ -400,10 +401,13 @@ def make_version_changes_layers(project_path, version):
             fields, cols_to_fields = create_field_list(db_schema[table_name])
             geom_type, geom_crs = get_layer_geometry_info(schema_json, table_name)
 
-            db_conn = None  # no ref. db
             db_conn = sqlite3.connect(gpkg_file)
-
-            features = diff_table_to_features(diff[table_name], db_schema[table_name], fields, cols_to_fields, db_conn)
+            try:
+                features = diff_table_to_features(
+                    diff[table_name], db_schema[table_name], fields, cols_to_fields, db_conn
+                )
+            finally:
+                db_conn.close()
 
             # create diff layer
             if geom_type is None:

--- a/Mergin/diff.py
+++ b/Mergin/diff.py
@@ -75,22 +75,22 @@ def get_row_from_db(db_conn, schema_table, entry_changes):
     Fetches a single row from DB's table based on the values of pkeys
     in changeset entry
     """
-    with db_conn.cursor() as c:
-        where_clauses = []
-        query_params = []
+    c = db_conn.cursor()
+    where_clauses = []
+    query_params = []
 
-        for i, col in enumerate(schema_table.columns):
-            if col.pkey:
-                where_clauses.append('"{}" = %s'.format(col.name))
-                val = old_value_for_column_by_index(entry_changes, i)
-                query_params.append(val)
+    for i, col in enumerate(schema_table.columns):
+        if col.pkey:
+            where_clauses.append('"{}" = ?'.format(col.name))
+            val = old_value_for_column_by_index(entry_changes, i)
+            query_params.append(val)
 
-        # We parameterize values securely; table/column names are trusted internal schema objects.
-        query = 'SELECT * FROM "{}" WHERE {}'.format(schema_table.name, " AND ".join(where_clauses))  # nosec B608
+    # We parameterize values securely; table/column names are trusted internal schema objects.
+    query = 'SELECT * FROM "{}" WHERE {}'.format(schema_table.name, " AND ".join(where_clauses))  # nosec B608
 
-        c.execute(query, tuple(query_params))
+    c.execute(query, tuple(query_params))
 
-        return c.fetchone()
+    return c.fetchone()
 
 
 def parse_gpkg_geom_encoding(wkb_with_gpkg_hdr):

--- a/Mergin/processing/algs/create_diff.py
+++ b/Mergin/processing/algs/create_diff.py
@@ -180,9 +180,13 @@ class CreateDiff(QgsProcessingAlgorithm):
         feedback.setProgress(30)
 
         if diff and table_name in diff.keys():
-            db_conn = None  # no ref. db
             db_conn = sqlite3.connect(layer_path)
-            features = diff_table_to_features(diff[table_name], db_schema[table_name], fields, fields_mapping, db_conn)
+            try:
+                features = diff_table_to_features(
+                    diff[table_name], db_schema[table_name], fields, fields_mapping, db_conn
+                )
+            finally:
+                db_conn.close()
             feedback.setProgress(40)
 
             step = 60.0 / len(features) if features else 0

--- a/Mergin/processing/algs/download_vector_tiles.py
+++ b/Mergin/processing/algs/download_vector_tiles.py
@@ -56,8 +56,7 @@ class MBTilesWriter:
             "CREATE UNIQUE INDEX tile_index on tiles (zoom_level, tile_column, tile_row);"
             "COMMIT;"
         )
-        cur = self.conn.cursor()
-        cur.executescript(sql)
+        self.conn.executescript(sql)
         return True
 
     def set_metadata_value(self, key, value):
@@ -65,8 +64,7 @@ class MBTilesWriter:
             return
 
         params = (key, value)
-        cur = self.conn.cursor()
-        cur.execute("insert into metadata values (?, ?)", params)
+        self.conn.execute("insert into metadata values (?, ?)", params)
         self.conn.commit()
 
     def set_tile_data(self, z, x, y, data):
@@ -74,8 +72,7 @@ class MBTilesWriter:
             return
 
         params = (z, x, y, data)
-        cur = self.conn.cursor()
-        cur.execute("insert into tiles values (?, ?, ?, ?)", params)
+        self.conn.execute("insert into tiles values (?, ?, ?, ?)", params)
         self.conn.commit()
 
     def close(self):

--- a/Mergin/processing/algs/extract_local_changes.py
+++ b/Mergin/processing/algs/extract_local_changes.py
@@ -115,9 +115,13 @@ class ExtractLocalChanges(QgsProcessingAlgorithm):
         feedback.setProgress(15)
 
         if diff and table_name in diff.keys():
-            db_conn = None  # no ref. db
             db_conn = sqlite3.connect(layer_path)
-            features = diff_table_to_features(diff[table_name], db_schema[table_name], fields, fields_mapping, db_conn)
+            try:
+                features = diff_table_to_features(
+                    diff[table_name], db_schema[table_name], fields, fields_mapping, db_conn
+                )
+            finally:
+                db_conn.close()
             feedback.setProgress(20)
 
             step = 80.0 / len(features) if features else 0


### PR DESCRIPTION
## Summary

  Fixes #895 — clicking a version in the Changes viewer raised:

  ```
  TypeError: 'sqlite3.Cursor' object does not support the context manager protocol
    at Mergin/diff.py:78 in get_row_from_db
  ```

  `get_row_from_db` in `Mergin/diff.py` was written with psycopg2 conventions even though `db_conn` is a stdlib `sqlite3.Connection`:

  - `with db_conn.cursor() as c:` — `sqlite3.Cursor` is not a context manager (only `sqlite3.Connection` is).
  - `'"{}" = %s'` placeholders — `sqlite3` uses `?`, not `%s`.

  ## Changes

  - Drop the `with` wrapper; assign cursor directly
  - `%s` → `?` for parameter placeholders.