### PR TITLE
Fix/issue 865 create action disabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Mergin/mergin
 .DS_Store
 mergin-py-client
 .qgis-settings
+CLAUDE.md

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -259,6 +259,7 @@ class MerginPlugin:
             self.manager = None
         if self.has_browser_item():
             self.data_item_provider.root_item.update_client_and_manager(mc=self.mc, manager=self.manager, err=error)
+        self.enable_toolbar_actions()
 
     def has_browser_item(self):
         """Check if the Mergin Maps provider Browser item exists and has the root item defined."""


### PR DESCRIPTION
### Summary

  Fixes #865 - at the QGIS welcome screen with no project open, the "Create Mergin Maps Project" toolbar action stays disabled. Opening any project (then optionally closing it) is required to get it to wake up.

  ### Root cause

  `enable_toolbar_actions` (`Mergin/plugin.py:291-303`) already has the correct special case for the Create button — it should be enabled whenever `self.mc` and `self.manager` are both set,
  regardless of whether a project is open. The bug is that **`create_manager()` never calls `enable_toolbar_actions()` after populating `self.mc`/`self.manager`** at startup. Other state-change paths
   (`on_config_changed`, `on_qgis_project_changed`) do, but the initial-load path does not — so on a clean QGIS launch the Create button stays at its initial `enabled=False` state until `on_qgis_project_changed` fires (i.e. a project is opened).

  ### Fix
  One line - call `self.enable_toolbar_actions()` at the end of `create_manager()`. The existing `mc`/`manager` check then enables the Create button at startup with no project required. The call is idempotent, and the same function is already invoked from the other state-change paths, so there is no behavioural risk elsewhere (the only side effect is a slightly redundant second call from `on_config_changed`, which is harmless).

<img width="1777" height="850" alt="image" src="https://github.com/user-attachments/assets/0113c5bc-3c0e-4f57-b3e2-f80e8567704c" />
