### PR TITLE
Export auth on browser panel sync

### DIFF
--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -482,6 +482,8 @@ class MerginPlugin:
 
     def current_project_sync(self):
         """Synchronise current Mergin Maps project."""
+        if not self.manager.check_project_server(self.mergin_proj_dir):
+            return
         AuthSync().export_auth(self.mc)
         self.manager.project_status(self.mergin_proj_dir)
 

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -54,7 +54,6 @@ from .utils_auth import (
     AuthTokenExpiredError,
     set_qgsexpressionscontext,
     get_authcfg,
-    AuthSync,
 )
 
 from .mergin.merginproject import MerginProject
@@ -482,9 +481,6 @@ class MerginPlugin:
 
     def current_project_sync(self):
         """Synchronise current Mergin Maps project."""
-        if not self.manager.check_project_server(self.mergin_proj_dir):
-            return
-        AuthSync().export_auth(self.mc)
         self.manager.project_status(self.mergin_proj_dir)
 
     def find_project(self):

--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -249,6 +249,7 @@ class MerginProjectsManager(object):
         if not self.check_project_server(project_dir):
             return
         try:
+            AuthSync().export_auth(self.mc)
             pull_changes, push_changes, push_changes_summary = self.mc.project_status(project_dir)
             dlg = ProjectStatusDialog(
                 pull_changes,


### PR DESCRIPTION
### Summary
Fixes #911 and #913.

  - **#911** — clicking the toolbar Sync button for a project downloaded from a different server raises an unhandled `ClientError` (HTTP 404), because `AuthSync().export_auth()` hits `client.project_info()` on the wrong server before any
  server-match check runs.
  - **#913** — `AuthSync().export_auth()` was only invoked from the toolbar Sync entry point; the Browser-tree sync skipped it entirely, so a user who updated credentials and synced from the Browser panel never pushed the new auth file.

 ### Fix
Move `AuthSync().export_auth(self.mc)` into `MerginProjectsManager.project_status()` — the chokepoint that both sync ways already flow through.

<img height="140" alt="image" src="https://github.com/user-attachments/assets/3f2a794e-9cc1-4de3-8e18-5126b1157d72" />
