### PR TITLE
Skip export_auth when synced project isn't open in QGIS

### DIFF
--- a/Mergin/projects_manager.py
+++ b/Mergin/projects_manager.py
@@ -249,7 +249,10 @@ class MerginProjectsManager(object):
         if not self.check_project_server(project_dir):
             return
         try:
-            AuthSync().export_auth(self.mc)
+            # Skip when the synced project isn't open in QGIS: AuthSync init would fail.
+            qgis_proj_filename = os.path.normpath(QgsProject.instance().fileName())
+            if qgis_proj_filename in find_qgis_files(project_dir):
+                AuthSync().export_auth(self.mc)
             pull_changes, push_changes, push_changes_summary = self.mc.project_status(project_dir)
             dlg = ProjectStatusDialog(
                 pull_changes,


### PR DESCRIPTION
Fixes #917 — regression from #912.

`AuthSync()` falls back to `QgsProject.instance()`, so triggering Sync on a Browser-panel project that isn't open in QGIS crashes. Reuse  "is this the open project?" check` to guard the `export_auth` call.