### PR TITLE
Indicate currently opened project in Browser (#919)

### DIFF
--- a/Mergin/data_item.py
+++ b/Mergin/data_item.py
@@ -141,14 +141,37 @@ class MerginLocalProjectItem(QgsDirectoryItem):
         self.project_name = posixpath.join(project["namespace"], project["name"])  # posix path for server API calls
         self.path = mergin_project_local_path(self.project_name)
         display_name = project["name"]
+        open_project_path = mergin_project_local_path()
+        self.is_open = (
+            self.path is not None and open_project_path is not None and same_dir(self.path, open_project_path)
+        )
+        if self.is_open:
+            display_name = f"{project['name']} • open"
         QgsDirectoryItem.__init__(self, parent, display_name, self.path, "/Mergin/" + self.project_name)
-        self.setSortKey(f"0 {self.name()}")
+        # put the opened project at the beginning of local entries.
+        self.setSortKey(f" 0 {project['name']}" if self.is_open else f"0 {self.name()}")
+        # QgsDirectoryItem.icon() ignores setIcon(), so cache the override and serve it from icon() instead.
+        self._open_icon = (
+            QIcon(os.path.join(os.path.dirname(__file__), "images", "folder-open.svg")) if self.is_open else None
+        )
         self.project = project
         self.project_manager = project_manager
         if self.project_manager is not None:
             self.mc = self.project_manager.mc
         else:
             self.mc = None
+
+    def icon(self):
+        """Provide the custom icon for the currently-open project; fall back to the default folder otherwise."""
+        if self.is_open and self._open_icon is not None:
+            return self._open_icon
+        return super().icon()
+
+    def equal(self, other):
+        """Called when the browser tree refreshes; also compare is_open so the diff detects open/close transitions."""
+        if not super().equal(other):
+            return False
+        return getattr(other, "is_open", False) == self.is_open
 
     def open_project(self):
         self.project_manager.open_project(self.path)
@@ -505,6 +528,11 @@ class MerginRootItem(QgsDataCollectionItem):
             return
         page_to_get = floor(len(self.projects) / PROJS_PER_PAGE) + 1
         self.fetch_projects(page=page_to_get)
+        self.refresh()
+
+    def reload_local(self):
+        """Re-read local projects from settings and refresh the tree."""
+        self.local_projects = []
         self.refresh()
 
     def reload(self):

--- a/Mergin/images/folder-open.svg
+++ b/Mergin/images/folder-open.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="#73D19C
+">
+  <path d="M5 4h4l3 3h7a2 2 0 0 1 2 2v8a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-11a2 2 0 0 1 2 -2z" />
+</svg>

--- a/Mergin/images/folder-open.svg
+++ b/Mergin/images/folder-open.svg
@@ -1,4 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="#73D19C
-">
-  <path d="M5 4h4l3 3h7a2 2 0 0 1 2 2v8a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2v-11a2 2 0 0 1 2 -2z" />
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="#73D19C">
+  <path d="M3 2h6l3 3h9a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-18a2 2 0 0 1 -2 -2v-15a2 2 0 0 1 2 -2z" />
 </svg>

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -541,7 +541,6 @@ class MerginPlugin:
             self.enable_toolbar_actions()
             set_qgis_project_mergin_variables(self.mergin_proj_dir)
         # re-render Browser items so the opened-project indicator follows the active QGIS project.
-        # reload_local() invalidates the local-projects cache
         if self.has_browser_item():
             self.data_item_provider.root_item.reload_local()
 

--- a/Mergin/plugin.py
+++ b/Mergin/plugin.py
@@ -540,6 +540,10 @@ class MerginPlugin:
         if self.mergin_proj_dir is not None:
             self.enable_toolbar_actions()
             set_qgis_project_mergin_variables(self.mergin_proj_dir)
+        # re-render Browser items so the opened-project indicator follows the active QGIS project.
+        # reload_local() invalidates the local-projects cache
+        if self.has_browser_item():
+            self.data_item_provider.root_item.reload_local()
 
     def add_context_menu_actions(self, layers):
         provider_names = "vectortile"


### PR DESCRIPTION
Resolves #919.

In the Mergin Maps Browser tree, the currently-open QGIS project is now visually distinguished from the rest of the projects:

- Pinned to the top of the local-projects section
- Brand-green folder icon
- ` • open` suffix appended to the project name.


The font tweaks are not implemented as `QgsBrowserModel` doesn't expose `Qt::FontRole` for `QgsDataItem`.

<img width="347" height="275" alt="image" src="https://github.com/user-attachments/assets/72adf8af-7420-448a-88f8-dc14bc8783cf" />


